### PR TITLE
Reboot wait_for fixes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
     delay: 30
     timeout: 600
     state: started
-  when: "ansible_distribution_version == '12.04' and reboot_result|success"
+  when: "ansible_distribution_version == '12.04' and reboot_result|changed"
 
 - name: Add Docker repository key
   apt_key: url="https://get.docker.io/gpg"


### PR DESCRIPTION
- `server_name` is an undefined variable, so `wait_for` will wait until the 600 second timeout and then fail
- `ansible_ssh_host` is only available when explicitly defined by inventory. If not `ansible_ssh_host` is not defined fall back to `inventory_hostname`.
- If the reboot task is skipped and `ansible_distribution_version` is 12.04, the `wait_for` task will still run, since technically the reboot command was successful as it did not fail due to not running.  Instead evaluate whether a change was reported.
