### PR TITLE
Use ansible_ssh_port if defined. Fixes #2

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
   local_action:
     module: wait_for
     host: "{{ hostvars[server_name]['ansible_ssh_host'] }}"
-    port: 22
+    port: "{{ ansible_ssh_port|default(22) }}"
     delay: 30
     timeout: 600
     state: started


### PR DESCRIPTION
Use ansible_ssh_port if defined. Fixes #2
