### PR TITLE
Add 'sudo: false' to wait_for task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,7 @@
       or (ansible_distribution_version == '13.10' and cgroup_lite_result|changed)"
 
 - name: Wait for instance to come online
+  sudo: false
   local_action:
     module: wait_for
     host: "{{ ansible_ssh_host|default(inventory_hostname) }}"


### PR DESCRIPTION
The wait_for task does not need to be run as sudo.  This ensures a playbook level sudo setting won't cause the task to fail if the ansible-playbook command was run without sudo.
