### PR TITLE
Prevent mlocate from indexing /var/lib/docker

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,6 +63,15 @@
   apt: pkg=lxc-docker
   notify: "Start Docker"
 
+- name: Check if /etc/updatedb.conf exists
+  stat: path=/etc/updatedb.conf
+  register: updatedb_conf_exists
+
+- name: Ensure updatedb does not index /var/lib/docker
+  shell: >
+    ex -s -c '/PRUNEPATHS=/v:/var/lib/docker:s:"$: /var/lib/docker"' -c 'wq' /etc/updatedb.conf
+  when: updatedb_conf_exists.stat.exists
+
 - name: Check if /etc/default/ufw exists
   stat: path=/etc/default/ufw
   register: ufw_default_exists


### PR DESCRIPTION
The standard updatedb configuration will scan almost all directories on the host and index their contents, except those listed in the PRUNEPATHS configuration setting in /etc/updatedb.conf. As this includes the /var/lib/docker directory, the mlocate.db file can grow to several gigabytes quickly when running just a few dozen containers. Therefore this patch will exclude the /var/lib/docker directory from being indexed as well.
