### PR TITLE
Generalize docker opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,15 @@ apt_key_url: http://get.docker.io/gpg
 apt_key_sig: A88D21E9
 # Name of the apt repository for docker
 apt_repository: deb http://get.docker.io/ubuntu docker main
-# The following help expose a docker port or to add additional options when running docker
-# The default is to not use any special options; see docker_opts
-#docker_host_ip: 0.0.0.0
-#docker_host_port: 2375
+
+# The following help expose a docker port or to add additional options when
+# running docker daemon.  The default is to not use any special options.
+#docker_opts: >
+#  -H unix://
+#  -H tcp://0.0.0.0:2375
+#  --log-level=debug
 docker_opts: ""
-#docker_opts: "-H unix:// -H tcp://{{ docker_host_ip }}:{{ docker_host_port }}"
+
 #docker_version: 1.2.0
 
 ```

--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ apt_repository: deb http://get.docker.io/ubuntu docker main
 docker_opts: ""
 #docker_opts: "-H unix:// -H tcp://{{ docker_host_ip }}:{{ docker_host_port }}"
 #docker_version: 1.2.0
-# Want to export the docker host?  You'll need to uncomment the docker_host_ip, port, opts
-export_docker_host: false
 
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,10 +13,13 @@ apt_key_url: http://get.docker.io/gpg
 apt_key_sig: A88D21E9
 # Name of the apt repository for docker
 apt_repository: deb http://get.docker.io/ubuntu docker main
-# The following help expose a docker port or to add additional options when running docker
-# The default is to not use any special options; see docker_opts
-#docker_host_ip: 0.0.0.0
-#docker_host_port: 2375
+
+# The following help expose a docker port or to add additional options when
+# running docker daemon.  The default is to not use any special options.
+#docker_opts: >
+#  -H unix://
+#  -H tcp://0.0.0.0:2375
+#  --log-level=debug
 docker_opts: ""
-#docker_opts: "-H unix:// -H tcp://{{ docker_host_ip }}:{{ docker_host_port }}"
+
 #docker_version: 1.2.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,5 +20,3 @@ apt_repository: deb http://get.docker.io/ubuntu docker main
 docker_opts: ""
 #docker_opts: "-H unix:// -H tcp://{{ docker_host_ip }}:{{ docker_host_port }}"
 #docker_version: 1.2.0
-# Want to export the docker host?  You'll need to uncomment the docker_host_ip, port, opts
-export_docker_host: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,7 +73,7 @@
 
 - name: Set docker daemon options
   copy:
-    content: "DOCKER_OPTS=\"{{ docker_opts }}\""
+    content: "DOCKER_OPTS=\"{{ docker_opts.rstrip('\n') }}\""
     dest: /etc/default/docker
     owner: root
     group: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,16 +71,16 @@
     update_cache: yes
     cache_valid_time: 600
 
-- name: Expose docker host
+- name: Set docker daemon options
   copy:
     content: "DOCKER_OPTS=\"{{ docker_opts }}\""
     dest: /etc/default/docker
     owner: root
     group: root
-    mode: 0744
+    mode: 0644
   notify:
     - Reload docker
-  when: "export_docker_host"
+  when: docker_opts
 
 - name: Fix DNS in docker.io
   lineinfile: 


### PR DESCRIPTION
Generalized and cleaned up setting docker options a bit.

There are various other options that you may want to set apart from specifying additional port to listen on, I think this way may be more readable if you need to do that.