### PR TITLE
Make kernel install task respect kernel_pkg_state

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: Install raring kernel onto 12.04
   apt:
     pkg: "{{ item }}"
-    state: latest
+    state: "{{ kernel_pkg_state }}"
     update_cache: yes
     cache_valid_time: 600
   with_items:


### PR DESCRIPTION
The kernel installation task on 12.04 wasn't respecting the option and
was always upgrading to latest.