### PR TITLE
Fix condition on task setting docker options

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,7 +80,7 @@
     mode: 0644
   notify:
     - Reload docker
-  when: docker_opts
+  when: docker_opts != ""
 
 - name: Fix DNS in docker.io
   lineinfile: 


### PR DESCRIPTION
When docker_opts is not set it defaults to an empty string which should
just evaluate to False in a boolean context, but for some reason was
failing with:

template error while templating string: Expected an expression, got 'end of statement block'