### PR TITLE
removed python-pip because of out-of-date request pkg

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,8 +105,11 @@
     update_cache: yes
     cache_valid_time: 600
   with_items:
+    - python-setuptools
     - python-dev
-    - python-pip
+
+- name: Upgrade pip
+  shell: easy_install --upgrade pip
 
 - name: Install Docker-py
   pip: 


### PR DESCRIPTION
I was encountering this error:
```
:stderr: Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    load_entry_point('pip==1.5.4', 'console_scripts', 'pip')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 351, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2363, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2088, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/usr/lib/python2.7/dist-packages/pip/__init__.py", line 11, in <module>
    from pip.vcs import git, mercurial, subversion, bazaar  # noqa
  File "/usr/lib/python2.7/dist-packages/pip/vcs/mercurial.py", line 9, in <module>
    from pip.download import path_to_url
  File "/usr/lib/python2.7/dist-packages/pip/download.py", line 25, in <module>
    from requests.compat import IncompleteRead
ImportError: cannot import name IncompleteRead
```
...after some research it sounds like the requests module referenced by python-pip is either out of date, or buggy.
https://github.com/docker/docker-py/issues/525

I'm now installing python-setuptools and upgrading pip through easy_install. This has fixed my problem.