### PR TITLE
Add variables for python package versions and set default to latest.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ install_xorg_pkgs: false
 # static binary provided by upstream Docker.  For example, see this GitHub Issue in Docker:
 # https://github.com/docker/docker/issues/12750
 install_kernel_extras: false
+# Versions for the python packages that are installed installed
+pip_version_pip: latest
+pip_version_setuptools: latest
+pip_version_docker_py: latest
 
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,3 +28,7 @@ install_xorg_pkgs: false
 # static binary provided by upstream Docker.  For example, see this GitHub Issue in Docker:
 # https://github.com/docker/docker/issues/12750
 install_kernel_extras: false
+# Versions for the python packages that are installed installed
+pip_version_pip: latest
+pip_version_setuptools: latest
+pip_version_docker_py: latest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -126,14 +126,28 @@
     - python-pip
 
 # Upgrade pip with pip to fix angstwad/docker.ubuntu/pull/35 and docker-py/issues/525
+# Install latest version when no specific release is set.
 - name: Upgrade latest pip, setuptools, and docker-py with pip
   pip:
-    name: "{{ item }}"
+    name: "{{ item.name }}"
     state: latest
   with_items:
-    - pip
-    - setuptools
-    - docker-py
+    - { name: pip, version: "{{ pip_version_pip }}" }
+    - { name: setuptools, version: "{{ pip_version_setuptools }}" }
+    - { name: docker-py, version: "{{ pip_version_docker_py }}" }
+  when: item.version=="latest"
+
+# Install specific version when set in the variables
+- name: Install specific pip, setuptools, and docker-py with pip
+  pip:
+    name: "{{ item.name }}"
+    state: present
+    version: "{{ item.version }}"
+  with_items:
+    - { name: pip, version: "{{ pip_version_pip }}" }
+    - { name: setuptools, version: "{{ pip_version_setuptools }}" }
+    - { name: docker-py, version: "{{ pip_version_docker_py }}" }
+  when: item.version!="latest"
 
 - name: Check if /etc/updatedb.conf exists
   stat:


### PR DESCRIPTION
PR as discussed in #40 
i needed to duplicate the pip task because version: and state:latest are not compatible. 
the defaults are set to latest.