### PR TITLE
Reboot instance is enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ install_kernel_extras: false
 pip_version_pip: latest
 pip_version_setuptools: latest
 pip_version_docker_py: latest
+# If this variable is set to true kernel updates and host restarts are permitted. Use with caution in production environments.
+kernel_update_and_reboot_permitted: no
 
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,3 +32,5 @@ install_kernel_extras: false
 pip_version_pip: latest
 pip_version_setuptools: latest
 pip_version_docker_py: latest
+# If this variable is set to true kernel updates and host restarts are permitted. Use with caution in production environments.
+kernel_update_and_reboot_permitted: no

--- a/tasks/kernel_check_and_update.yml
+++ b/tasks/kernel_check_and_update.yml
@@ -1,0 +1,62 @@
+- name: Install backported trusty kernel onto 12.04
+  apt:
+    pkg: "{{ item }}"
+    state: "{{ kernel_pkg_state }}"
+    update_cache: yes
+    cache_valid_time: 600
+  with_items:
+    - linux-image-generic-lts-trusty
+    - linux-headers-generic-lts-trusty
+  register: kernel_result
+  when: "ansible_distribution_version|version_compare(12.04, '=')"
+
+- name: Install Xorg packages for backported kernels (very optional)
+  apt:
+    pkg: "{{ item }}"
+    state: installed
+    update_cache: yes
+    cache_valid_time: 600
+  with_items:
+    - xserver-xorg-lts-trusty
+    - libgl1-mesa-glx-lts-trusty
+  register: xorg_pkg_result
+  when: "install_xorg_pkgs and (kernel_result|changed or kernel_result|success)"
+
+- name: Install latest kernel extras for Ubuntu 13.04+
+  apt:
+    pkg: "linux-image-extra-{{ ansible_kernel }}"
+    state: "{{ kernel_pkg_state }}"
+    update_cache: yes
+    cache_valid_time: 600
+  when: "ansible_distribution_version|version_compare(13.04, '=')
+      or ansible_distribution_version|version_compare(13.10, '=')
+      or install_kernel_extras"
+
+# Fix for https://github.com/dotcloud/docker/issues/4568
+- name: Install cgroup-lite for Ubuntu 13.10
+  apt:
+    pkg: cgroup-lite
+    state: "{{ cgroup_lite_pkg_state }}"
+    update_cache: yes
+    cache_valid_time: 600
+  register: cgroup_lite_result
+  when: "ansible_distribution_version|version_compare(13.10, '=')"
+
+- name: Reboot instance
+  command: /sbin/shutdown -r now
+  register: reboot_result
+  when: "(ansible_distribution_version|version_compare(12.04, '=') and kernel_result|changed)
+      or (ansible_distribution_version|version_compare(13.10, '=') and cgroup_lite_result|changed)
+      or xorg_pkg_result|changed"
+
+- name: Wait for instance to come online (10 minute timeout)
+  sudo: false
+  local_action:
+    module: wait_for
+    host: "{{ ansible_ssh_host|default(inventory_hostname) }}"
+    port: "{{ ansible_ssh_port|default(ssh_port) }}"
+    delay: 30
+    timeout: 600
+    state: started
+  when: "(ansible_distribution_version|version_compare(12.04, '=') and reboot_result|changed)
+      or (ansible_distribution_version|version_compare(13.10, '=') and cgroup_lite_result|changed)"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,68 +5,9 @@
     msg: "{{ ansible_distribution_version }} is not an acceptable version of Ubuntu for this role"
   when: ansible_distribution_version|version_compare(12.04, '<') or ansible_distribution_version|version_compare(12.10, '=')
 
-- name: Install backported trusty kernel onto 12.04
-  apt:
-    pkg: "{{ item }}"
-    state: "{{ kernel_pkg_state }}"
-    update_cache: yes
-    cache_valid_time: 600
-  with_items:
-    - linux-image-generic-lts-trusty
-    - linux-headers-generic-lts-trusty
-  register: kernel_result
-  when: "ansible_distribution_version|version_compare(12.04, '=')"
-
-- name: Install Xorg packages for backported kernels (very optional)
-  apt:
-    pkg: "{{ item }}"
-    state: installed
-    update_cache: yes
-    cache_valid_time: 600
-  with_items:
-    - xserver-xorg-lts-trusty
-    - libgl1-mesa-glx-lts-trusty
-  register: xorg_pkg_result
-  when: "install_xorg_pkgs and (kernel_result|changed or kernel_result|success)"
-
-- name: Install latest kernel extras for Ubuntu 13.04+
-  apt:
-    pkg: "linux-image-extra-{{ ansible_kernel }}"
-    state: "{{ kernel_pkg_state }}"
-    update_cache: yes
-    cache_valid_time: 600
-  when: "ansible_distribution_version|version_compare(13.04, '=')
-      or ansible_distribution_version|version_compare(13.10, '=')
-      or install_kernel_extras"
-
-# Fix for https://github.com/dotcloud/docker/issues/4568
-- name: Install cgroup-lite for Ubuntu 13.10
-  apt:
-    pkg: cgroup-lite
-    state: "{{ cgroup_lite_pkg_state }}"
-    update_cache: yes
-    cache_valid_time: 600
-  register: cgroup_lite_result
-  when: "ansible_distribution_version|version_compare(13.10, '=')"
-
-- name: Reboot instance
-  command: /sbin/shutdown -r now
-  register: reboot_result
-  when: "(ansible_distribution_version|version_compare(12.04, '=') and kernel_result|changed)
-      or (ansible_distribution_version|version_compare(13.10, '=') and cgroup_lite_result|changed)
-      or xorg_pkg_result|changed"
-
-- name: Wait for instance to come online (10 minute timeout)
-  sudo: false
-  local_action:
-    module: wait_for
-    host: "{{ ansible_ssh_host|default(inventory_hostname) }}"
-    port: "{{ ansible_ssh_port|default(ssh_port) }}"
-    delay: 30
-    timeout: 600
-    state: started
-  when: "(ansible_distribution_version|version_compare(12.04, '=') and reboot_result|changed)
-      or (ansible_distribution_version|version_compare(13.10, '=') and cgroup_lite_result|changed)"
+- name: update kernel
+  include: kernel_check_and_update.yml
+  when: kernel_update_and_reboot_permitted
 
 - name: Add Docker repository key
   apt_key:


### PR DESCRIPTION
I don't think it's a good idea. What if you accidentally run this on a production 12.04?

Here's how I solve this for my lxc role:

```
- name: update kernel
  include: kernel_check_and_update.yml
  when: update_kernel_if_required
```

```update_kernel_if_required``` is set to false in defaults.

Can I make a pull request with such a fix?