### PR TITLE
Update condition to allow pkg name with version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -175,7 +175,7 @@
   service:
     name: docker
     state: started
-  when: docker_pkg_name == 'lxc-docker'
+  when: docker_pkg_name.find('lxc-docker') != -1
 
 - name: Start docker.io
   service:


### PR DESCRIPTION
I am setting `docker_pkg_name` to `lxc-docker-{version}`