### PR TITLE
Update default apt_repository variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ apt_key_url: http://get.docker.io/gpg
 # apt repository key signature
 apt_key_sig: A88D21E9
 # Name of the apt repository for docker
-apt_repository: deb http://get.docker.io/ubuntu docker main
+apt_repository: deb https://get.docker.com/ubuntu docker main
 # The following help expose a docker port or to add additional options when
 # running docker daemon.  The default is to not use any special options.
 #docker_opts: >

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ apt_key_url: http://get.docker.io/gpg
 # apt repository key signature
 apt_key_sig: A88D21E9
 # Name of the apt repository for docker
-apt_repository: deb http://get.docker.io/ubuntu docker main
+apt_repository: deb https://get.docker.com/ubuntu docker main
 # The following help expose a docker port or to add additional options when
 # running docker daemon.  The default is to not use any special options.
 #docker_opts: >


### PR DESCRIPTION
The official docker install-script (https://get.docker.com/ and https://get.docker.com/ubuntu/) now use https://get.docker.com as their base url. This PR reflects that change. 
Using the old url, I ran into problems when doing an apt-get update.