### PR TITLE
Fix idempotence of updating /etc/updatedb.conf

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,8 +96,12 @@
   register: updatedb_conf_exists
 
 - name: Ensure updatedb does not index /var/lib/docker
-  shell: >
-    ex -s -c '/PRUNEPATHS=/v:/var/lib/docker:s:"$: /var/lib/docker"' -c 'wq' /etc/updatedb.conf
+  lineinfile:
+    dest: /etc/updatedb.conf
+    state: present
+    backrefs: yes
+    regexp: '^PRUNEPATHS="(/var/lib/docker )?(.*)"$'
+    line: 'PRUNEPATHS="/var/lib/docker \2"'
   when: updatedb_conf_exists.stat.exists
 
 - name: Check if /etc/default/ufw exists


### PR DESCRIPTION
In the current implementation, the step "Ensure updatedb does not index /var/lib/docker" always returns "changed" even when the contents of the file are not changed. This change modifies that task to act idempotently, thereby fixing the accuracy of the status returned for this task.

**Testing:**
* Ran with the included `Vagrantfile` for ubuntu-12.04 and ubuntu-14.04
* Upon a second invokation of `vagrant provision` I see that the task no longer returned a status of "changed"

    ```
TASK: [docker.ubuntu | Ensure updatedb does not index /var/lib/docker] ********
<127.0.0.1> REMOTE_MODULE lineinfile line='PRUNEPATHS="/var/lib/docker \2"' state=present regexp='^PRUNEPATHS="(/var/lib/docker )?(.*)"$' dest=/etc/updatedb.conf
ok: [ubuntu-1404] => {"backup": "", "changed": false, "msg": ""}

...

PLAY RECAP ********************************************************************
ubuntu-1404                : ok=12   changed=0    unreachable=0    failed=0
```

* I do see that `/var/lib/docker` was added to `PRUNEPATHS` in `/etc/updatedb.conf`:
    ```
$ v ssh ubuntu-1404  -- cat /etc/updatedb.conf
PRUNE_BIND_MOUNTS="yes"
# PRUNENAMES=".git .bzr .hg .svn"
PRUNEPATHS="/var/lib/docker /tmp /var/spool /media /home/.ecryptfs"
```