### PR TITLE
docker updates brake api

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ pip_version_docker_py: latest
 # If this variable is set to true kernel updates and host restarts are permitted.
 # Warning: Use with caution in production environments.
 kernel_update_and_reboot_permitted: no
+# Set to 'yes' or 'true' to enable updates (sets 'latest' in apt module)
+update_docker_package: no
 # Change these to 'present' if you're running Ubuntu 12.04-13.10 and are fine with less-than-latest packages
 kernel_pkg_state: latest
 cgroup_lite_pkg_state: latest

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,9 @@ pip_version_docker_py: latest
 # If this variable is set to true kernel updates and host restarts are permitted.
 # Warning: Use with caution in production environments.
 kernel_update_and_reboot_permitted: no
+
+# Set to 'yes' or 'true' to enable updates (sets 'latest' in apt module)
+update_docker_package: no
 # Change these to 'present' if you're running Ubuntu 12.04-13.10 and are fine with less-than-latest packages
 kernel_pkg_state: latest
 cgroup_lite_pkg_state: latest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Install (or update) docker package
   apt:
     name: "{{ docker_pkg_name }}"
-    state: latest
+    state: "{{ 'latest' if update_docker_package else 'present' }}"
     update_cache: yes
     cache_valid_time: 600
 


### PR DESCRIPTION
Recent docker update leaded to docker_image module incompatibility. At this point I would like to change default behaviour from ```latest``` to ```present``` and allow setting ```latest``` with a variable. Breaking everything with just a simple playbook run doesn't seem to be nice in production.

Any objections?