### PR TITLE
Added facts update if ansible_docker0 is not defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -138,3 +138,7 @@
     append: yes
   with_items: docker_group_members
   when: docker_group_members is defined
+
+- name: update facts if docker0 is not defined
+  action: setup
+  when: ansible_docker0 is not defined


### PR DESCRIPTION
Useful if docker is installed in the same play as roles that use related facts. Could also fix #39.