### PR TITLE
* Try to start the service `docker` when docker package name includes `docker-engine`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -122,7 +122,7 @@
   service:
     name: docker
     state: started
-  when: docker_pkg_name.find('lxc-docker') != -1
+  when: docker_pkg_name.find('lxc-docker') != -1 or docker_pkg_name.find('docker-engine') != -1
 
 - name: Start docker.io
   service:


### PR DESCRIPTION
On the first run, it's started automatically
But on other runs, it doesn't.
Also even if the service is started already, this won't change the service state.