### PR TITLE
Support for DOCKER_OPTS on Ubuntu 15.04

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,5 +6,11 @@
 - name: Reload docker
   service: name=docker state=reloaded
 
+- name: Reload systemd
+  command: systemctl daemon-reload  
+
+- name: Restart docker
+  service: name=docker state=restarted
+
 - name: Restart dockerio
   service: name=docker.io state=restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,19 +37,39 @@
     mode: 0644
   notify:
     - Reload docker
-  when: docker_opts != ""
+  when: docker_opts != "" and ansible_distribution_version|version_compare(15.04, '<')
 
-- name: Ensure docker daemon options are picked up (systemd)
+- name: Create systemd configuration directory for Docker service (systemd)
+  file: 
+    dest: /etc/systemd/system/docker.service.d 
+    state: directory
+    owner: root
+    group: root
+    mode: 0755 
+  when: docker_opts != "" and ansible_distribution_version|version_compare(15.04, '>=')
+
+- name: Set docker daemon options (systemd)
   copy:
-    content: >
+    content: |
       [Service]
-      EnvironmentFile=/etc/default/docker
-    dest: /etc/systemd/system/docker.service.d/DockerEnv.conf
+      Environment="DOCKER_OPTS={{ docker_opts.rstrip('\n') }}"
+    dest: /etc/systemd/system/docker.service.d/env.conf
     owner: root
     group: root
     mode: 0644
   notify:
-    - Reload docker
+    - Reload systemd
+    - Restart docker
+  when: docker_opts != "" and ansible_distribution_version|version_compare(15.04, '>=')
+
+- name: Ensure docker daemon options used (systemd)
+  lineinfile:
+    dest: /lib/systemd/system/docker.service
+    regexp: "ExecStart=/usr/bin/docker daemon -H fd://"
+    line: ExecStart=/usr/bin/docker daemon -H fd:// $DOCKER_OPTS
+  notify:
+    - Reload systemd
+    - Restart docker
   when: docker_opts != "" and ansible_distribution_version|version_compare(15.04, '>=')
 
 - name: Fix DNS in docker.io

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,19 @@
     - Reload docker
   when: docker_opts != ""
 
+- name: Ensure docker daemon options are picked up (systemd)
+  copy:
+    content: >
+      [Service]
+      EnvironmentFile=/etc/default/docker
+    dest: /etc/systemd/system/docker.service.d/DockerEnv.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - Reload docker
+  when: docker_opts != "" and ansible_distribution_version|version_compare(15.04, '>=')
+
 - name: Fix DNS in docker.io
   lineinfile:
     dest: "{{ docker_defaults_file_path }}"


### PR DESCRIPTION
With the introduction of systemd on 15.04, the existing DOCKER_OPTS implementation does not work. This pull request should address that by editing the ExecStart line in the systemd unit, and adding a side-load config file to /etc/systemd/system/docker.service.d/ to include those docker options. Had to refactor the handlers slightly as well as "reloaded" doesn't play nice with systemd, it seems.