### PR TITLE
Use "docker_apt_cache_valid_time" for installing python-dev & python-pip

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,7 +100,7 @@
     pkg: "{{ item }}"
     state: latest
     update_cache: yes
-    cache_valid_time: 600
+    cache_valid_time: "{{ docker_apt_cache_valid_time }}"
   with_items:
     - python-dev
     - python-pip


### PR DESCRIPTION
In #75, I'd parameterized the apt-cache's valid-time for installing "docker-engine", but missed the parameterization of the apt-cache valid time for installing python-dev & python-pip. This change fixes that omission.

Adding this because it will allow the playbook runs to complete faster, without unnecessary "apt-get update"s.

Thanks!