### PR TITLE
Fixed deprecation warning message

### DIFF
--- a/docker.yml
+++ b/docker.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: all
-  sudo: true
+  become: yes
   roles:
     - { role: ./,
         docker_opts: "-H tcp://127.0.0.1:4243 -H unix:///var/run/docker.sock --dns 8.8.8.8 --dns 8.8.4.4"

--- a/tasks/kernel_check_and_update.yml
+++ b/tasks/kernel_check_and_update.yml
@@ -53,7 +53,7 @@
       or xorg_pkg_result|changed"
 
 - name: Wait for instance to come online (10 minute timeout)
-  sudo: false
+  become: no
   local_action:
     module: wait_for
     host: "{{ ansible_ssh_host|default(inventory_hostname) }}"

--- a/tests/vagrant.yml
+++ b/tests/vagrant.yml
@@ -1,7 +1,7 @@
 ---
 # test file for docker.ubuntu role on vagrant
 - hosts: all
-  sudo: true
+  become: yes
 
   vars:
     docker_group_members: [ '{{ ansible_ssh_user }}' ]


### PR DESCRIPTION
I kept getting this message:
```
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make 
sure become_method is 'sudo' (default). This feature will be removed in a future 
release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```
So I fixed it.