### PR TITLE
Fix outdated key in alternative key-add task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   ignore_errors: true
 
 - name: Alternative | Add Docker repository key
-  shell: curl -sSL https://get.docker.com/gpg | sudo apt-key add -
+  shell: "curl -sSL {{ apt_key_url }} | sudo apt-key add -"
   when: add_repository_key|failed
 
 - name: Add Docker repository and update apt cache


### PR DESCRIPTION
Alternative add-key task curl'ed the key from wrong location `https://get.docker.com/gpg`. 
Correct one is `https://apt.dockerproject.org/gpg`, which is defined as `apt_key_url` variable and correctly used during the primary add-key task.