### PR TITLE
Restart rather than reload docker.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,9 +3,6 @@
 - name: Start Docker
   service: name=docker state=started
 
-- name: Reload docker
-  service: name=docker state=reloaded
-
 - name: Reload systemd
   command: systemctl daemon-reload  
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
     group: root
     mode: 0644
   notify:
-    - Reload docker
+    - Restart docker
   when: docker_opts != "" and ansible_distribution_version|version_compare(15.04, '<')
 
 - name: Create systemd configuration directory for Docker service (systemd)


### PR DESCRIPTION
Fix for issue #89

state=reloaded doesn't actually have any effect on a running
docker process in ubuntu 14.04. In particular, the /etc/init.d/docker
start script does not execute, so any customised storage options will
not be applied to the running docker process which may result in
a big surprise when the daemon is eventually restarted and images
added to the loopback thin pool device are no longer accessible in
the configured thinpool device.

This change removes the "Reload docker" handler and changes the pre 15.04
handler to use "Restart docker" instead.