### PR TITLE
Set repository file mode 644, as system default

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,7 @@
 - name: Add Docker repository and update apt cache
   apt_repository:
     repo: "{{ apt_repository }}"
+    mode: '644'
     update_cache: yes
     state: present
 


### PR DESCRIPTION
It could cause error 

> ifstream::ifstream (13: Permission denied)

 in some tasks.