### PR TITLE
Use keyserver when adding rero key

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Add Docker repository key
   apt_key:
     id: "{{ apt_key_sig }}"
-    url: "{{ apt_key_url }}"
+    keyserver: "{{ apt_key_url }}"
     state: present
   register: add_repository_key
   ignore_errors: true


### PR DESCRIPTION
It's better to use keyserver instead of url in apt_key module, because defining an url will perform an HTTP request to get the key, whereas defining a keyserver will perform a request to get a specific key from that server (possibly using some other protocol). For example, currently docker documentation uses hkp://p80.pool.sks-keyservers.net:80 that will not work with url, but will work good with keyserver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/angstwad/docker.ubuntu/106)
<!-- Reviewable:end -->
