### PR TITLE
Ubuntu 16.04 requires dmsetup to be installed before docker.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,6 +45,7 @@ update_docker_package: no
 # Change these to 'present' if you're running Ubuntu 12.04-13.10 and are fine with less-than-latest packages
 kernel_pkg_state: latest
 cgroup_lite_pkg_state: latest
+dmsetup_pkg_state: latest
 # Force an install of the kernel extras, in case you're suffering from some issue related to the
 # static binary provided by upstream Docker.  For example, see this GitHub Issue in Docker:
 # https://github.com/docker/docker/issues/12750

--- a/tasks/kernel_check_and_update.yml
+++ b/tasks/kernel_check_and_update.yml
@@ -63,3 +63,17 @@
     state: started
   when: "(ansible_distribution_version|version_compare(12.04, '=') and reboot_result|changed)
       or (ansible_distribution_version|version_compare(13.10, '=') and cgroup_lite_result|changed)"
+
+# Fix for https://github.com/docker/docker/issues/23347
+- name: Install dmsetup for Ubuntu 16.04
+  apt:
+    pkg: dmsetup
+    state: "{{ dmsetup_pkg_state }}"
+    update_cache: yes
+    cache_valid_time: 600
+  register: dmsetup_result
+  when: "ansible_distribution_version|version_compare(16.04, '=')"
+
+- name: Run dmsetup for Ubuntu 16.04
+  command: dmsetup mknodes
+  when: dmsetup_result

--- a/tasks/kernel_check_and_update.yml
+++ b/tasks/kernel_check_and_update.yml
@@ -63,17 +63,3 @@
     state: started
   when: "(ansible_distribution_version|version_compare(12.04, '=') and reboot_result|changed)
       or (ansible_distribution_version|version_compare(13.10, '=') and cgroup_lite_result|changed)"
-
-# Fix for https://github.com/docker/docker/issues/23347
-- name: Install dmsetup for Ubuntu 16.04
-  apt:
-    pkg: dmsetup
-    state: "{{ dmsetup_pkg_state }}"
-    update_cache: yes
-    cache_valid_time: 600
-  register: dmsetup_result
-  when: "ansible_distribution_version|version_compare(16.04, '=')"
-
-- name: Run dmsetup for Ubuntu 16.04
-  command: dmsetup mknodes
-  when: dmsetup_result

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
     update_cache: yes
     cache_valid_time: 600
   register: dmsetup_result
-  when: "ansible_distribution_version|version_compare(16.04, '=')"
+  when: ansible_distribution_version|version_compare(16.04, '=')
 
 - name: Run dmsetup for Ubuntu 16.04
   command: dmsetup mknodes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,20 @@
   include: kernel_check_and_update.yml
   when: kernel_update_and_reboot_permitted or install_kernel_extras
 
+# Fix for https://github.com/docker/docker/issues/23347
+- name: Install dmsetup for Ubuntu 16.04
+  apt:
+    pkg: dmsetup
+    state: "{{ dmsetup_pkg_state }}"
+    update_cache: yes
+    cache_valid_time: 600
+  register: dmsetup_result
+  when: "ansible_distribution_version|version_compare(16.04, '=')"
+
+- name: Run dmsetup for Ubuntu 16.04
+  command: dmsetup mknodes
+  when: dmsetup_result
+
 - name: Add Docker repository key
   apt_key:
     id: "{{ apt_key_sig }}"


### PR DESCRIPTION
Otherwise dpkg cannot install docker (installation hangs)
See details here: https://github.com/docker/docker/issues/23347