### PR TITLE
Make sure vars in when statement are using {{var}}

### DIFF
--- a/tasks/kernel_check_and_update.yml
+++ b/tasks/kernel_check_and_update.yml
@@ -8,7 +8,7 @@
     - linux-image-generic-lts-trusty
     - linux-headers-generic-lts-trusty
   register: kernel_result
-  when: "ansible_distribution_version|version_compare(12.04, '=')"
+  when: "{{ ansible_distribution_version|version_compare(12.04, '=') }}"
 
 - name: Install Xorg packages for backported kernels (very optional)
   apt:
@@ -20,7 +20,7 @@
     - xserver-xorg-lts-trusty
     - libgl1-mesa-glx-lts-trusty
   register: xorg_pkg_result
-  when: "install_xorg_pkgs and (kernel_result|changed or kernel_result|success)"
+  when: "{{ install_xorg_pkgs }} and ( {{ kernel_result|changed }} or {{ kernel_result|success }} )"
 
 - name: Install latest kernel for Ubuntu 13.04+
   apt:
@@ -31,9 +31,9 @@
   with_items:
     - "linux-image-extra-{{ ansible_kernel }}"
     - linux-image-extra-virtual
-  when: "ansible_distribution_version|version_compare(13.04, '=')
-      or ansible_distribution_version|version_compare(13.10, '=')
-      or install_kernel_extras"
+  when: "{{ ansible_distribution_version|version_compare(13.04, '=') }}
+      or {{ ansible_distribution_version|version_compare(13.10, '=') }}
+      or {{ install_kernel_extras }}"
 
 # Fix for https://github.com/dotcloud/docker/issues/4568
 - name: Install cgroup-lite for Ubuntu 13.10
@@ -43,14 +43,14 @@
     update_cache: yes
     cache_valid_time: 600
   register: cgroup_lite_result
-  when: "ansible_distribution_version|version_compare(13.10, '=')"
+  when: "{{ ansible_distribution_version|version_compare(13.10, '=') }}"
 
 - name: Reboot instance
   command: /sbin/shutdown -r now
   register: reboot_result
-  when: "(ansible_distribution_version|version_compare(12.04, '=') and kernel_result|changed)
-      or (ansible_distribution_version|version_compare(13.10, '=') and cgroup_lite_result|changed)
-      or xorg_pkg_result|changed"
+  when: "( {{ ansible_distribution_version|version_compare(12.04, '=') }} and {{ kernel_result|changed }} )
+      or ( {{ ansible_distribution_version|version_compare(13.10, '=') }} and {{ cgroup_lite_result|changed }} )
+      or {{ xorg_pkg_result|changed }}"
 
 - name: Wait for instance to come online (10 minute timeout)
   become: no
@@ -61,5 +61,5 @@
     delay: 30
     timeout: 600
     state: started
-  when: "(ansible_distribution_version|version_compare(12.04, '=') and reboot_result|changed)
-      or (ansible_distribution_version|version_compare(13.10, '=') and cgroup_lite_result|changed)"
+  when: "( {{ ansible_distribution_version|version_compare(12.04, '=') }} and {{ reboot_result|changed }} )
+      or ( {{ ansible_distribution_version|version_compare(13.10, '=') }} and {{ cgroup_lite_result|changed }} )"


### PR DESCRIPTION
When using ansible v2.1.0.0 I'm having issues this statement evaluating to True:
https://github.com/angstwad/docker.ubuntu/blob/master/tasks/kernel_check_and_update.yml#L34-L36

Even when each evaluate to False individually. 

```
ansible_distribution_version|version_compare(13.04, '=') == False
ansible_distribution_version|version_compare(13.10, '=') == False
install_kernel_extras == False

"ansible_distribution_version|version_compare(13.04, '=') or
      ansible_distribution_version|version_compare(13.10, '=') or
      install_kernel_extras" == True
```

This is causing the task `Install latest kernel for Ubuntu 13.04+` to run on my Ubuntu 12.04 box.

The issue seems to be resolved when using the `{{ var }}` syntax. For good measure I modified all of the `when:` statements in `kernel_check_and_update.yml` to use the `{{ var }}` syntax.