### PR TITLE
Add necessary linux-image-extra-* apt packages

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,16 @@
   register: dmsetup_result
   when: ansible_distribution_version|version_compare(16.04, '=')
 
+- name: Read uname
+  shell: uname -r
+  register: uname_output
+
+- name: Install linux-image-extra-* packages to enable AuFS driver
+  apt: pkg={{ item }} state=present
+  with_items:
+    - linux-image-extra-{{ uname_output.stdout }}
+    - linux-image-extra-virtual
+
 - name: Run dmsetup for Ubuntu 16.04
   command: dmsetup mknodes
   when: dmsetup_result


### PR DESCRIPTION
Required for AuFS - without it our boxes lockup.

Fixes https://github.com/angstwad/docker.ubuntu/issues/115