### PR TITLE
Configurable proxy in the docker config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ apt_repository: deb https://apt.dockerproject.org/repo {{ ansible_lsb.id|lower }
 #  -H tcp://0.0.0.0:2375
 #  --log-level=debug
 docker_opts: ""
+
+# configurable proxies: a reasonable default is to re-use the proxy from ansible_env:
+# docker_http_proxy: "{{ ansible_env.http_proxy|default('') }}"
+# Notes:
+# if docker_http_proxy==""   the role sets HTTP_PROXY="" (useful to 'empty' existing ENV var)
+# if docker_http_proxy is undefined the role will not set/modify any ENV vars
+docker_http_proxy:
+docker_https_proxy:
+
 # List of users to be added to 'docker' system group (disabled by default)
 # SECURITY WARNING: 
 # Be aware that granted users can easily get full root access on the docker host system!

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,15 @@ docker_opts: ""
 # SECURITY WARNING: 
 # Be aware that granted users can easily get full root access on the docker host system!
 docker_group_members: []
+
+# configurable proxies: a reasonable default is to re-use the proxy from ansible_env:
+# docker_http_proxy: "{{ ansible_env.http_proxy|default('') }}"
+# Notes:
+# if docker_http_proxy==""   the role sets HTTP_PROXY="" (useful to 'empty' existing ENV var)
+# if docker_http_proxy is undefined the role will not set/modify any ENV vars
+docker_http_proxy:
+docker_https_proxy:
+
 # Flags for whether to install pip packages
 pip_install_pip: true
 pip_install_setuptools: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -203,12 +203,16 @@
   when: ufw_default_exists.stat.exists
 
 - name: Set docker proxy settings if proxy env. vars are defined
-  lineinfile: dest=/etc/default/docker line="{{item}}" state=present
+  lineinfile:
+    dest: /etc/default/docker
+    line: "{{item}}"
+    state: present
   when: ansible_env.http_proxy is defined
   with_items:
     - "export HTTP_PROXY={{ansible_env.http_proxy}}"
     - "export HTTPS_PROXY={{ansible_env.https_proxy}}"
-  notify: "Reload docker"
+  notify:
+    - Restart docker
 
 - name: Start docker
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -206,21 +206,23 @@
   lineinfile:
     dest: /etc/default/docker
     regexp: "^export HTTP_PROXY="
-    line: "export HTTP_PROXY={{ansible_env.https_proxy}}"
+    line: "export HTTP_PROXY=\"{{ansible_env.http_proxy}}\""
     state: present
   when: ansible_env.http_proxy is defined
   notify:
     - Restart docker
+  tags: proxy
 
 - name: Set docker proxy settings if https_proxy env. var is defined
   lineinfile:
     dest: /etc/default/docker
     regexp: "^export HTTPS_PROXY="
-    line: "export HTTPS_PROXY={{ansible_env.https_proxy}}"
+    line: "export HTTPS_PROXY=\"{{ansible_env.https_proxy}}\""
     state: present
   when: ansible_env.https_proxy is defined
   notify:
     - Restart docker
+  tags: proxy
 
 - name: Start docker
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -202,24 +202,24 @@
     line: "DEFAULT_FORWARD_POLICY=\"ACCEPT\""
   when: ufw_default_exists.stat.exists
 
-- name: Set docker proxy settings if http_proxy env. var is defined
+- name: Set docker HTTP_PROXY if docker_http_proxy defined
   lineinfile:
     dest: /etc/default/docker
     regexp: "^export HTTP_PROXY="
-    line: "export HTTP_PROXY=\"{{ansible_env.http_proxy}}\""
+    line: "export HTTP_PROXY=\"{{docker_http_proxy}}\""
     state: present
-  when: ansible_env.http_proxy is defined
+  when: docker_http_proxy is defined and (docker_http_proxy != None)
   notify:
     - Restart docker
   tags: proxy
 
-- name: Set docker proxy settings if https_proxy env. var is defined
+- name: Set docker HTTPS_PROXY if docker_https_proxy defined
   lineinfile:
     dest: /etc/default/docker
     regexp: "^export HTTPS_PROXY="
-    line: "export HTTPS_PROXY=\"{{ansible_env.https_proxy}}\""
+    line: "export HTTPS_PROXY=\"{{docker_https_proxy}}\""
     state: present
-  when: ansible_env.https_proxy is defined
+  when: docker_https_proxy is defined and (docker_https_proxy != None)
   notify:
     - Restart docker
   tags: proxy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -202,15 +202,23 @@
     line: "DEFAULT_FORWARD_POLICY=\"ACCEPT\""
   when: ufw_default_exists.stat.exists
 
-- name: Set docker proxy settings if proxy env. vars are defined
+- name: Set docker proxy settings if http_proxy env. var is defined
   lineinfile:
     dest: /etc/default/docker
-    line: "{{item}}"
+    regexp: "^export HTTP_PROXY="
+    line: "export HTTP_PROXY={{ansible_env.https_proxy}}"
     state: present
   when: ansible_env.http_proxy is defined
-  with_items:
-    - "export HTTP_PROXY={{ansible_env.http_proxy}}"
-    - "export HTTPS_PROXY={{ansible_env.https_proxy}}"
+  notify:
+    - Restart docker
+
+- name: Set docker proxy settings if https_proxy env. var is defined
+  lineinfile:
+    dest: /etc/default/docker
+    regexp: "^export HTTPS_PROXY="
+    line: "export HTTPS_PROXY={{ansible_env.https_proxy}}"
+    state: present
+  when: ansible_env.https_proxy is defined
   notify:
     - Restart docker
 


### PR DESCRIPTION
WiP

In an old/closed PR comment, I gave different proposals on howto make this more configurable:
https://github.com/angstwad/docker.ubuntu/pull/25#issuecomment-265760460

Notes:
* proposal (1) is already outdated, after my latest fixes.
* proposal (2) can be improved:

```
docker_http_proxy_enabled: false
docker_http_proxy: "{{ docker_http_proxy_enabled | ternary(ansible_env.http_proxy|default(''), '') }}"
docker_https_proxy: "{{ docker_http_proxy_enabled | ternary(ansible_env.https_proxy|default(''), '') }}"

docker_https_proxy: "{{ansible_env.https_proxy | default('') }}"
```

Note: the general `docker_http_proxy_enabled` var could still be useful  (to set to 'true' and the 2 other vars to 'empty string') to disable existing HTTP(S)_PROXY (by setting the same env-vars to empty ('') values)
