### PR TITLE
Check ubuntu version before installing linux-image-extra-

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,7 @@
   with_items:
     - linux-image-extra-{{ uname_output.stdout }}
     - linux-image-extra-virtual
+  when: ansible_distribution_version|version_compare(14.04, '>=')
 
 - name: Run dmsetup for Ubuntu 16.04
   command: dmsetup mknodes


### PR DESCRIPTION
Need to do a version check before installing `linux-image-extra-` packages as per:
https://docs.docker.com/engine/installation/linux/ubuntulinux/

Fixes #123 