### PR TITLE
Fix dmsetup run condition

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
 
 - name: Run dmsetup for Ubuntu 16.04
   command: dmsetup mknodes
-  when: dmsetup_result
+  when: dmsetup_result.changed
 
 - name: Add Docker repository key
   apt_key:


### PR DESCRIPTION
dmsetup_result is a non empty dictionary, it will always be evaluated
to True.