### PR TITLE
Run the read uname task even in check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,7 @@
   shell: uname -r
   register: uname_output
   changed_when: false
+  always_run: yes
 
 - name: Install linux-image-extra-* packages to enable AuFS driver
   apt:


### PR DESCRIPTION
Otherwise the 'Install linux-image-extra-* packages' task fails in check
mode as it uses the result of the read uname task.