### PR TITLE
Handle docker-compose version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -156,6 +156,15 @@
     - python-dev
     - python-pip
 
+# Display an informative message if the docker-compose version needs to be downgraded
+- name: Docker-compose version downgrade
+  debug:
+    msg: >-
+      Downgrading docker-compose version to {{ _pip_version_docker_compose }} because of docker-compose > 1.10
+      requiring docker python package (instead of the docker-py one) which is incompatible with the docker_container
+      module in Ansible < 2.3
+  when: pip_install_docker_compose and _pip_version_docker_compose != pip_version_docker_compose
+
 # Upgrade pip with pip to fix angstwad/docker.ubuntu/pull/35 and docker-py/issues/525
 - name: Install pip, setuptools, docker-py and docker-compose with pip
   pip:
@@ -166,7 +175,7 @@
     - { name: pip, version: "{{ pip_version_pip }}", install: "{{ pip_install_pip }}" }
     - { name: setuptools, version: "{{ pip_version_setuptools }}", install: "{{ pip_install_setuptools }}" }
     - { name: docker-py, version: "{{ pip_version_docker_py }}", install: "{{ pip_install_docker_py }}" }
-    - { name: docker-compose, version: "{{ pip_version_docker_compose }}", install: "{{ pip_install_docker_compose }}" }
+    - { name: docker-compose, version: "{{ _pip_version_docker_compose }}", install: "{{ pip_install_docker_compose }}" }
   when: item.install
 
 - name: Check if /etc/updatedb.conf exists

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,6 +2,7 @@
 # Downgrade docker-compose version if ansible version < 2.3 and docker-compose > 1.9.0
 # Because of docker-compose 1.10+ requires docker python package (instead of the docker-py one)
 # which is incompatible with the docker_container module in Ansible < 2.3
+# TODO: update ansible version in the comparison when https://github.com/ansible/ansible/issues/20492 gets fixed.
 _pip_version_docker_compose: >-
     {{ '1.9.0' if ansible_version.full | version_compare('2.3', '<')
         and (pip_version_docker_compose=='latest' or pip_version_docker_compose | version_compare('1.9.0', '>'))

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,8 @@
+---
+# Downgrade docker-compose version if ansible version < 2.3 and docker-compose > 1.9.0
+# Because of docker-compose 1.10+ requires docker python package (instead of the docker-py one)
+# which is incompatible with the docker_container module in Ansible < 2.3
+_pip_version_docker_compose: >-
+    {{ '1.9.0' if ansible_version.full | version_compare('2.3', '<')
+        and (pip_version_docker_compose=='latest' or pip_version_docker_compose | version_compare('1.9.0', '>'))
+        else pip_version_docker_compose }}


### PR DESCRIPTION
docker-compose > 1.10 requires the docker python package which is
incompatible with the docker_container module in Ansible < 2.3.

This fixes #135.