### PR TITLE
remove all trailing whitespace from custom docker options config

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,7 +88,7 @@
 
 - name: Set docker daemon options
   copy:
-    content: "DOCKER_OPTS=\"{{ docker_opts.rstrip('\n') }}\""
+    content: "DOCKER_OPTS=\"{{ docker_opts.rstrip() }}\""
     dest: /etc/default/docker
     owner: root
     group: root
@@ -110,7 +110,7 @@
   copy:
     content: |
       [Service]
-      Environment="DOCKER_OPTS={{ docker_opts.rstrip('\n') }}"
+      Environment="DOCKER_OPTS={{ docker_opts.rstrip() }}"
     dest: /etc/systemd/system/docker.service.d/env.conf
     owner: root
     group: root


### PR DESCRIPTION
Python's `rstrip` function calls were not stripping whitespace from the role's `docker_opts` option. This caused the created file at `/etc/systemd/system/docker.service.d/env.conf` to have an extra line, like so:

```
[Service]
Environment="DOCKER_OPTS=--graph=/data-01/.docker-data
"
```

The options were then not loaded properly by the Docker daemon.

This PR removes _all_ whitespace from the end of the `docker_opts` setting, which removes the extra line (as well as any other whitespace, which should not be needed).

```
Local:
Python 2.7.12
ansible 2.0.1.0

Remote:
Ubuntu 16.04 on EC2
Linux ip-10-0-1-80 4.4.0-53-generic #74-Ubuntu SMP Fri Dec 2 15:59:10 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
```