### PR TITLE
fixed test role not found + added Ubuntu 16.04 test

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,9 +21,16 @@ boxes = [
     :ram => "256"
   },
   {
+    :name => "ubuntu-1604",
+    :box => "ubuntu/xenial64",
+    :ip => '10.0.77.13',
+    :cpu => "33",
+    :ram => "512"
+  },
+  {
     :name => "debian-jessie",
     :box => "debian/jessie64",
-    :ip => '10.0.77.13',
+    :ip => '10.0.77.14',
     :cpu => "33",
     :ram => "256"
   },
@@ -42,6 +49,11 @@ Vagrant.configure("2") do |config|
       end
 
       vms.vm.network :private_network, ip: box[:ip]
+
+      # neccessary for ubuntu 16.04 and harmless for the rest
+      vms.vm.provision :shell do |shell|
+        shell.inline = "DEBIAN_FRONTEND=noninteractive apt-get -y install python-simplejson"
+      end
 
       vms.vm.provision :ansible do |ansible|
         ansible.playbook = "tests/vagrant.yml"

--- a/tests/vagrant.yml
+++ b/tests/vagrant.yml
@@ -7,4 +7,4 @@
     docker_group_members: [ '{{ ansible_ssh_user }}' ]
 
   roles:
-    - docker.ubuntu
+    - { role: ../../docker.ubuntu }


### PR DESCRIPTION
I added a vagrant test case for Ubuntu 16.04.
apparently the step:
"Install pip, python-dev package with apt" takes too much ram and crashes that why i doubled the amount of ram for the Ubuntu 16.04 test box.

Also I had to addjust the path to the role since it said it cant find the docker role in the "tests/.." directory in vagrant...
maybe instead of ../../docker.ubuntu  ../. can  be used too since with my fix the checkout folder must be exacly the name of the repository (which is default ).

Also because of Ubuntu 16.04 not having the necessary python2 modules I needed to add a shell provisioner installing it (which does no harm to the other boxes either).

In my personal Ansible bootsrap script I always doo this with a raw tasks in front of everything else (also with disables fact gathering) here this seemed the nicer solution since this is only a single role that is meant to be included. 