### PR TITLE
Command "daemon" is deprecated

### DIFF
--- a/templates/docker.conf
+++ b/templates/docker.conf
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=/usr/bin/docker daemon -H fd:// $DOCKER_OPTS
+ExecStart=/usr/bin/dockerd -H fd:// $DOCKER_OPTS


### PR DESCRIPTION
Command "daemon" is deprecated, and will be removed in Docker 17.12.