### PR TITLE
Let users could specify docker daemon start up environment variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,13 @@ docker_group_members: []
 docker_http_proxy:
 docker_https_proxy:
 
+# add extra environment variables like log driver key id and secrect key
+# example:
+# docker_extra_envs:
+#   - { param: 'AWS_ACCESS_KEY_ID',  value: 'AEDMIDIEKDICOSLEID' }
+#   - ( param: 'AWS_SECRET_ACCESS_KEY', value: '2340iklzmkwe09i6lknfgnmklmwelrgk' }
+docker_extra_envs: []
+
 # Flags for whether to install pip packages
 pip_install_pip: true
 pip_install_setuptools: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -140,13 +140,13 @@
     - Restart docker
   when: docker_opts != "" and is_systemd
 
-  - name: Set docker daemon environment variables (systemd)
-    lineinfile:
-      dest: /etc/default/docker
-      regexp: "Environment {{ item.param }}="
-      line: 'Environment {{ item.param }}="{{ item.value }}"'
-    with_items: "{{ docker_extra_envs }}"
-    when: docker_extra_envs != []
+- name: Set docker daemon environment variables (systemd)
+  lineinfile:
+    dest: /etc/default/docker
+    regexp: "Environment {{ item.param }}="
+    line: 'Environment {{ item.param }}="{{ item.value }}"'
+  with_items: "{{ docker_extra_envs }}"
+  when: docker_extra_envs != []
 
 - name: Ensure docker daemon options used (systemd)
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -109,6 +109,14 @@
     - Restart docker
   when: docker_opts != "" and not is_systemd
 
+- name: Set docker daemon environment variables
+  lineinfile:
+    dest: /etc/default/docker
+    regexp: "{{ item.param }}="
+    line: '{{ item.param }}="{{ item.value }}"'
+  with_items: "{{ docker_extra_envs }}"
+  when: docker_extra_envs != []
+
 - name: Create systemd configuration directory for Docker service (systemd)
   file:
     dest: /etc/systemd/system/docker.service.d
@@ -131,6 +139,14 @@
     - Reload systemd
     - Restart docker
   when: docker_opts != "" and is_systemd
+
+  - name: Set docker daemon environment variables (systemd)
+    lineinfile:
+      dest: /etc/default/docker
+      regexp: "Environment {{ item.param }}="
+      line: 'Environment {{ item.param }}="{{ item.value }}"'
+    with_items: "{{ docker_extra_envs }}"
+    when: docker_extra_envs != []
 
 - name: Ensure docker daemon options used (systemd)
   template:

--- a/tests/vagrant.retry
+++ b/tests/vagrant.retry
@@ -1,0 +1,1 @@
+ubuntu-1604-python3

--- a/tests/vagrant.yml
+++ b/tests/vagrant.yml
@@ -12,6 +12,9 @@
   vars:
     docker_group_members:
       - "{{ ansible_ssh_user }}"
+    docker_extra_envs:
+      - { param: 'AWS_ACCESS_KEY_ID',  value: 'AEDMIDIEKDICOSLEID' }
+      - ( param: 'AWS_SECRET_ACCESS_KEY', value: '2340iklzmkwe09i6lknfgnmklmwelrgk' }
   roles:
     - role: docker.ubuntu
       kernel_update_and_reboot_permitted: yes

--- a/tests/vagrant.yml
+++ b/tests/vagrant.yml
@@ -13,8 +13,8 @@
     docker_group_members:
       - "{{ ansible_ssh_user }}"
     docker_extra_envs:
-      - { param: 'AWS_ACCESS_KEY_ID',  value: 'AEDMIDIEKDICOSLEID' }
-      - ( param: 'AWS_SECRET_ACCESS_KEY', value: '2340iklzmkwe09i6lknfgnmklmwelrgk' }
+      - { param: "AWS_ACCESS_KEY_ID",  value: "AEDMIDIEKDICOSLEID" }
+      - { param: "AWS_SECRET_ACCESS_KEY", value: "2340iklzmkwe09i6lknfgnmklmwelrgk" }
   roles:
     - role: docker.ubuntu
       kernel_update_and_reboot_permitted: yes


### PR DESCRIPTION
But I got this error and don't know how to fix:
```TASK [docker.ubuntu : Clean previous docker-py package if installing docker.] ***
task path: /home/shenghan/Codes/docker.ubuntu/tasks/main.yml:195
fatal: [ubuntu-1204]: FAILED! => {"failed": true, "msg": "The conditional check '(_pip_install_docker or pip_install_docker_compose) and _pip_docker_package_name == 'docker'' failed. The error was: {{ 'docker-py' if _pip_version_docker | version_compare('1.10.6', '<=') else 'docker' }}: Version comparison: unorderable types: str() < int()\n\nThe error appears to have been in '/home/shenghan/Codes/docker.ubuntu/tasks/main.yml': line 195, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n# See vars/main.yml for more information on this.\n- name: Clean previous docker-py package if installing docker.\n  ^ here\n"}
```