### PR TITLE
Unpack vars to correct version_compare issue

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,21 +19,29 @@ python_vars_file: >-
 #   * you have to use docker-py<=1.10.6 due to backward incompatibilities of next versions
 #   * you have to use docker-compose<=1.9.0 due to docker-compose>1.9.0 using newer versions of docker-py.
 
+# Compute Ansible version or latest
+_ansible_version_latest: "{{ ansible_version.full | version_compare('2.3', '<') }}"
+
+# Compute Python Docker component version or latest
+_pip_version_docker_latest: >-
+  {{ pip_version_docker=='latest' or (pip_version_docker | version_compare('1.10.6', '>')) }}
+
+# Compute Python Docker-compose component version or latest
+_pip_version_docker_compose_latest: >-
+  {{ pip_version_docker_compose=='latest' or (pip_version_docker_compose | version_compare('1.9.0', '>')) }}
+
 # Compute the `docker` Python package's version to use.
 _pip_version_docker: >-
-    {{ '1.10.6' if ansible_version.full | version_compare('2.3', '<')
-        and (pip_version_docker=='latest' or pip_version_docker | version_compare('1.10.6', '>'))
-        else pip_version_docker }}
+  {{ '1.10.6' if (_ansible_version_latest and _pip_version_docker_latest) else pip_version_docker }}
 
 # Compute the `docker` Python package's name according to its version.
-_pip_docker_package_name: "{{ 'docker-py' if _pip_version_docker | version_compare('1.10.6', '<=') else 'docker' }}"
+_pip_docker_package_name: "{{ 'docker-py' if not _pip_version_docker_latest else 'docker' }}"
 
-# Determine whether to install the `docker` package or not. The `docker-compose` Python package has a dependency over the `docker` Python package.
-# So when installing the `docker-compose` package we'd rather let it handle the `docker` package version to prevent version mismatches.
+# Determine whether to install the `docker` package or not. The `docker-compose` Python package has a dependency over
+# the `docker` Python package. So when installing the `docker-compose` package we'd rather let it handle the `docker`
+# package version to prevent version mismatches.
 _pip_install_docker: "{{ not pip_install_docker_compose and pip_install_docker }}"
 
 # Compute the `docker-compose` Python package's version to use.
 _pip_version_docker_compose: >-
-    {{ '1.9.0' if ansible_version.full | version_compare('2.3', '<')
-        and (pip_version_docker_compose=='latest' or pip_version_docker_compose | version_compare('1.9.0', '>'))
-        else pip_version_docker_compose }}
+  {{ '1.9.0' if (_ansible_version_latest and _pip_version_docker_compose_latest) else pip_version_docker_compose }}


### PR DESCRIPTION
I discovered an issue with the `version_compare` when running this role via Ansible 2.3 on Ubuntu 12.04. It seems that the interpreter can get confused in the tightly packed vars, so I broke out version comparators into their own vars. This seems to have fixed the issue.