### PR TITLE
Adding GNUPG-curl verification to role.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,6 +67,13 @@
   command: dmsetup mknodes
   when: dmsetup_result.changed
 
+- name: Ensure GNUPG-curl is available for https
+  apt:
+    pkg: gnupg-curl
+    state: present
+    update_cache: yes
+    cache_valid_time: "{{ docker_apt_cache_valid_time }}"
+
 - name: Add Docker repository key
   apt_key:
     id: "{{ apt_key_sig }}"


### PR DESCRIPTION
Solves the first part of #178. Still doesn't solve the issue of not having `curl`, but if you've got `gnupg-curl` you shouldn't have to touch that task.