### PR TITLE
Sre 695

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # docker-engine is the default package name
-docker_pkg_name: docker-engine
+docker_pkg_version: 17.05.0
+docker_pkg_edition: ce
+docker_pkg_name: docker-engine={{ docker_pkg_version }}~{{ docker_pkg_edition }}-0~{{ansible_lsb.id|lower }}-{{ ansible_lsb.codename|lower }}
 docker_apt_cache_valid_time: 600
 
 # docker dns path for docker.io package ( changed at ubuntu 14.04 from docker to docker.io )

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,7 +54,7 @@ pip_version_docker_compose: latest
 kernel_update_and_reboot_permitted: no
 
 # Set to 'yes' or 'true' to enable updates (sets 'latest' in apt module)
-update_docker_package: no
+update_docker_package: yes
 
 # Change these to 'present' if you're running Ubuntu 12.04-13.10 and are fine with less-than-latest packages
 kernel_pkg_state: latest


### PR DESCRIPTION
 Add versioning to docker to update to docker_pkg_version. The only thing that should be changed is the docker_pkg_version.


Update to latest package. Since the version is pinned, it would make sure any old version is updated. For versions older than ce, docker_pkg_name can be changed to be for example  `1.13.1-0~ubuntu-trusty`



