### PR TITLE
Make gnupg_curl a variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ docker_aufs_enabled: true
 # docker dns path for docker.io package ( changed at ubuntu 14.04 from docker to docker.io )
 docker_defaults_file_path: /etc/default/docker
 
+# The package name required for gnupg curl
 apt_gnupg_curl_pkg: gnupg-curl
 
 # Important if running Ubuntu 12.04-13.10 and ssh on a non-standard port

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,8 @@ docker_aufs_enabled: true
 # docker dns path for docker.io package ( changed at ubuntu 14.04 from docker to docker.io )
 docker_defaults_file_path: /etc/default/docker
 
+apt_gnupg_curl_pkg: gnupg-curl
+
 # Important if running Ubuntu 12.04-13.10 and ssh on a non-standard port
 ssh_port: 22
 # Place to get apt repository key

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,7 +69,7 @@
 
 - name: Ensure GNUPG-curl is available for https
   apt:
-    pkg: gnupg-curl
+    pkg: "{{ apt_gnupg_curl_pkg }}"
     state: present
     update_cache: yes
     cache_valid_time: "{{ docker_apt_cache_valid_time }}"


### PR DESCRIPTION
A defence in depth solution for the naming of packages (especially as this step was necessary for the role to work on Ubuntu 17.04). This keeps the default package but allows user override should they need to use `gnupg2` or `gnupg1-curl` to complete installation.