### PR TITLE
Add support for Debian Stretch (9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ create some VMs:
 * Ubuntu 14.04
 * Ubuntu 16.04
 * Debian Jessie 8.5
+* Debian Stretch 9.0
 
 and it will provision them by applying this role with Ansible.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,28 +10,35 @@ boxes = [
     :name => "ubuntu-1404",
     :box => "ubuntu/trusty64",
     :ip => '10.0.77.12',
-    :cpu => "33",
+    :cpu => "20",
     :ram => "256"
   },
   {
     :name => "ubuntu-1604",
     :box => "ubuntu/xenial64",
     :ip => '10.0.77.13',
-    :cpu => "33",
+    :cpu => "20",
     :ram => "512"
   },
   {
     :name => "debian-jessie",
     :box => "debian/jessie64",
     :ip => '10.0.77.14',
-    :cpu => "33",
+    :cpu => "20",
+    :ram => "256"
+  },
+  {
+    :name => "debian-stretch",
+    :box => "debian/stretch64",
+    :ip => '10.0.77.16',
+    :cpu => "20",
     :ram => "256"
   },
   {
     :name => "ubuntu-1604-python3",
     :box => "ubuntu/xenial64",
     :ip => '10.0.77.15',
-    :cpu => "33",
+    :cpu => "20",
     :ram => "512"
   },
 ]

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,7 @@ galaxy_info:
     - name: Debian
       versions:
         - jessie
+        - stretch
     - name: Ubuntu
       versions:
         - trusty

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,6 +73,15 @@
     state: present
     update_cache: yes
     cache_valid_time: "{{ docker_apt_cache_valid_time }}"
+  when: ansible_lsb.codename|lower != "stretch"  # Debian Stretch does not have gnupg-curl, see below to at least install curl
+
+- name: Ensure at least curl is available for https
+  apt:
+    pkg: "curl"
+    state: present
+    update_cache: yes
+    cache_valid_time: "{{ docker_apt_cache_valid_time }}"
+  when: ansible_lsb.codename|lower == "stretch"
 
 - name: Add Docker repository key
   apt_key:


### PR DESCRIPTION
Everything except gnupg-curl works well on Debian Stretch. This add a minimal if-clause for gnupg-curl support.