### PR TITLE
Fix environment values' quote position

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -140,7 +140,7 @@
 - name: Creates override directory (systemd)
   file:
     path: /etc/systemd/system/docker.service.d
-    state: "{{ daemon_json is not none or docker_http_proxy_defined or docker_https_proxy_defined | ternary('directory', 'absent') }}"
+    state: "{{ (daemon_json is not none or docker_http_proxy_defined or docker_https_proxy_defined)|ternary('directory', 'absent') }}"
     owner: root
     group: root
     mode: 0755

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -300,7 +300,7 @@
   copy:
     content: |
       [Service]
-      Environment="{% if docker_http_proxy_defined %}http_proxy={{ docker_http_proxy }}{% endif %} {% if docker_https_proxy_defined %}https_proxy={{ docker_https_proxy }}{% endif %} no_proxy={{ docker_no_proxy | default('') }}"
+      Environment={% if docker_http_proxy_defined %}"http_proxy={{ docker_http_proxy }}"{% endif %} {% if docker_https_proxy_defined %}"https_proxy={{ docker_https_proxy }}"{% endif %} "no_proxy={{ docker_no_proxy | default('') }}"
     dest: /etc/systemd/system/docker.service.d/proxy.conf
     owner: root
     group: root


### PR DESCRIPTION
@angstwad please review this PR as it fix a stupid bug introduced by #160 

Double quote around all values will make docker think all values belongs to http_proxy like this:
```
$ sudo docker info | grep -i proxy
Http Proxy: http://proxy.intra.menghan.me:8888 HTTPS_PROXY=http://proxy.intra.menghan.me:8888 NO_PROXY=registry.intra.menghan.me,localhost,127.0.0.0/8,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,172.30.1.1
```

This pr fix the problem to:
```
$ sudo docker info | grep -i proxy
Http Proxy: http://proxy.intra.menghan.me:8888                               
Https Proxy: http://proxy.intra.menghan.me:8888
No Proxy: registry.intra.menghan.me,localhost,127.0.0.0/8,192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,172.30.1.1
```