### PR TITLE
Fix for #175 & other changes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,17 +14,19 @@ docker_aufs_enabled: true
 # docker dns path for docker.io package ( changed at ubuntu 14.04 from docker to docker.io )
 docker_defaults_file_path: /etc/default/docker
 
-# The package name required for gnupg curl
-apt_gnupg_curl_pkg: gnupg-curl
+# The package name required for dirmngr (required key installation to work on some deb systems)
+apt_dirmngr_pkg: dirmngr
 
 # Important if running Ubuntu 12.04-13.10 and ssh on a non-standard port
 ssh_port: 22
 # Place to get apt repository key
-apt_key_url: https://download.docker.com/linux/ubuntu/gpg
+apt_key_url: "hkp://ha.pool.sks-keyservers.net"
 # apt repository key signature
 apt_key_sig: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+# apt keyring file
+keyring: "/etc/apt/trusted.gpg.d/docker.gpg"
 # Name of the apt repository for Docker CE or EE
-apt_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_lsb.id|lower }} {{ ansible_lsb.codename|lower }} stable"
+apt_repository: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} stable"
 
 # daemon_json allows you to configure the daemon with the daemon.json file.
 # https://docs.docker.com/engine/reference/commandline/dockerd/#on-linux

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,16 +32,6 @@
     - docker.io
   when: uninstall_previous_docker_versions
 
-# Fix for https://github.com/docker/docker/issues/23347
-- name: Install dmsetup for Ubuntu 16.04
-  apt:
-    pkg: dmsetup
-    state: "{{ dmsetup_pkg_state }}"
-    update_cache: "{{ 'yes' if dmsetup_pkg_state=='latest' else 'no' }}"
-    cache_valid_time: "{{ docker_apt_cache_valid_time }}"
-  register: dmsetup_result
-  when: ansible_distribution_version|version_compare('16.04', '=')
-
 - name: Install linux-image-extra-* packages to enable AuFS driver
   apt:
     pkg: "{{ item }}"
@@ -63,26 +53,13 @@
     cache_valid_time: "{{ docker_apt_cache_valid_time }}"
   when: linux_image_extra_install|failed
 
-- name: Run dmsetup for Ubuntu 16.04
-  command: dmsetup mknodes
-  when: dmsetup_result.changed
-
-- name: Ensure GNUPG-curl is available for https
+- name: Ensure dirmngr is available
   apt:
-    pkg: "{{ apt_gnupg_curl_pkg }}"
+    pkg: "{{ apt_dirmngr_pkg }}"
     state: present
     update_cache: yes
     cache_valid_time: "{{ docker_apt_cache_valid_time }}"
-  when: ansible_lsb.codename|lower != "stretch"  # Debian Stretch does not have gnupg-curl, see below to at least install curl
-
-- name: Ensure at least curl is available for https
-  apt:
-    pkg: "curl"
-    state: present
-    update_cache: yes
-    cache_valid_time: "{{ docker_apt_cache_valid_time }}"
-  when: ansible_lsb.codename|lower == "stretch"
-
+  
 - name: Add Docker repository key
   apt_key:
     id: "{{ apt_key_sig }}"
@@ -92,7 +69,7 @@
   ignore_errors: true
 
 - name: Alternative | Add Docker repository key
-  shell: "curl -sSL {{ apt_key_url }} | sudo apt-key add -"
+  shell: "apt-key adv --fetch-keys {{ apt-key-url }}"
   when: add_repository_key|failed
 
 - name: HTTPS APT transport for Docker repository
@@ -123,7 +100,7 @@
 - name: Set systemd playbook var
   set_fact:
     is_systemd: true
-  when: ( ansible_lsb.id|lower == "ubuntu" and ansible_distribution_version|version_compare('15.04', '>=') or ansible_lsb.id|lower == "debian" )
+  when: ( ansible_distribution_release == "Ubuntu" and ansible_distribution_version|version_compare('15.04', '>=') or ansible_distribution == "Debian" )
   tags: always
 
 - name: Set docker_http_proxy_defined flag


### PR DESCRIPTION
I made some changes that deviated slightly from the official docker install instructions, specifically with regards to the apt-key installation. There is, I think a better way to execute it that works more consistently between Debian & Ubuntu and doesn't require gnupg-curl to make that happen. I also changed key servers because during testing I was getting intermittent failures using the docker keyserver. The server I have in there now is, IIRC the server that used to be in their own install script and hasn't produced any failures. At some point in the future, adding a fallback mode with the docker server or vice-versa to obtain the key is probably a good idea. 

I removed the workaround for dmsetup because that issue was resolved docker side with an update. 

I spun up several VMs for Debian 9 & Ubuntu 16.04.3 created with install media pulled in the past week. Used minimal installation profiles (incl openssh & python) for testing. Running this role against those VMs repeatedly resulted in successful installation of docker with no errors. 

Feel free to use or not use any of the changes. I needed it working on Debian 9, and in the state it was in it was broken. I initially fixed that for my needs, but then it didn't work on Ubuntu. Since you indicated you didn't think you would get to #175, it seemed like fixing it for both and submitting a PR was a good way to contribute back for the use of the role you created. The other changes were a "While I'm already in here, why don't I..." kind of thing.