### PR TITLE
Flush fixes and adjustment to default bridge ip option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,13 @@ docker_http_proxy:
 docker_https_proxy:
 docker_no_proxy:
 
+# Optionally allow the bridge IP to change, to prevent conflicts or allow more control
+docker_bip:
+
+# Flag to determine if we should flush handlers mid way through role. This is useful if we want docker to make use of our new
+# options right away
+docker_flush_handlers: true
+
 # Flags for whether to install pip packages
 pip_install_pip: true
 pip_install_setuptools: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -330,3 +330,19 @@
   setup:
     filter: "ansible_docker0"
   when: ansible_docker0 is not defined
+
+- name: Add different cidr for docker bridge
+  copy:
+    content: |
+      {
+        "bip": "{{ docker_bip }}"
+      }
+    dest: /etc/docker/daemon.json
+  when: docker_bip is not none
+  notify:
+    - Restart docker
+
+# Flush handlers so things like proxy settings are picked up or new bridge ip
+- name: Force handler flush so the config is picked up
+  meta: flush_handlers
+  when: docker_flush_handlers


### PR DESCRIPTION
* Add flush handler at the end of main, this is to allow config options
  to be picked up once the role has finished. In my case setting proxies
  and bridge ip. Without this line it requires two Ansible runs due to
  nature of handlers.

* Added configurable option for bridge ip. By default it conflicts with
  my ip schema. This is now a configurable option.