### PR TITLE
add var start_docker_daemon to only (re)start docker daemon if it is true

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,6 +102,6 @@ install_kernel_extras: false
 install_xorg_pkgs: false
 
 # Set to 'no' if docker daemon shall not be started.
-# (e.g. in case of a machine which only controlls other docker hosts via docker-machine)
+# (e.g. in case of a machine which only controls other docker hosts via docker-machine)
 start_docker_daemon: true
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -100,3 +100,8 @@ install_kernel_extras: false
 # where an X/Unit desktop is actively being used. If you're not using an X/Unity on 12.04, you
 # won't need to enable this.
 install_xorg_pkgs: false
+
+# Set to 'no' if docker daemon shall not be started.
+# (e.g. in case of a machine which only controlls other docker hosts via docker-machine)
+start_docker_daemon: true
+

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,12 +2,15 @@
 # handlers file for docker.ubuntu
 - name: Start Docker
   service: name=docker state=started
+  when: start_docker_daemon
 
 - name: Reload systemd
   command: systemctl daemon-reload  
 
 - name: Restart docker
   service: name=docker state=restarted
+  when: start_docker_daemon
 
 - name: Restart dockerio
   service: name=docker.io state=restarted
+  when: start_docker_daemon

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -316,6 +316,7 @@
   service:
     name: docker
     state: started
+  when: start_docker_daemon
 
   # ATTENTION: this task can potentially create new users!
 - name: Add users to the docker group


### PR DESCRIPTION
I have some servers which only have docker installed but no docker daemon running. They are only used to controll other docker hosts using docker-machine.

The systemd docker deamon is masked to prevent the dockerd from running accidently. This leads to errors wich this ansible playbook since a couple of days.

That do you think about this PR ? It helps me to run the playbook successfully on all my hosts again.
