### PR TITLE
Revert "Flush fixes and adjustment to default bridge ip option"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,13 +56,6 @@ docker_http_proxy:
 docker_https_proxy:
 docker_no_proxy:
 
-# Optionally allow the bridge IP to change, to prevent conflicts or allow more control
-docker_bip:
-
-# Flag to determine if we should flush handlers mid way through role. This is useful if we want docker to make use of our new
-# options right away
-docker_flush_handlers: true
-
 # Flags for whether to install pip packages
 pip_install_pip: true
 pip_install_setuptools: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -330,19 +330,3 @@
   setup:
     filter: "ansible_docker0"
   when: ansible_docker0 is not defined
-
-- name: Add different cidr for docker bridge
-  copy:
-    content: |
-      {
-        "bip": "{{ docker_bip }}"
-      }
-    dest: /etc/docker/daemon.json
-  when: docker_bip is not none
-  notify:
-    - Restart docker
-
-# Flush handlers so things like proxy settings are picked up or new bridge ip
-- name: Force handler flush so the config is picked up
-  meta: flush_handlers
-  when: docker_flush_handlers


### PR DESCRIPTION
This has the potential to overwrite the the `daemon.json` file if `docker_bip` is set, which is not ideal for obvious reasons. 

Setting `bip` attribute on the `daemon_json` object should be enough to solve for this issue.  An additional flush handlers could be added in the future if necessary. 

Reverts angstwad/docker.ubuntu#203