### PR TITLE
Allow selection of apt channel

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,9 @@ uninstall_previous_docker_versions: false
 # assume that the desired version is community edition
 docker_edition: ce
 
+# which channel to pull from the apt repository
+docker_apt_channel: stable
+
 # docker-ce is the default package name
 docker_pkg_name: "{{ 'docker-ee' if docker_edition == 'ee' else 'docker-ce' }}"
 docker_apt_cache_valid_time: 600
@@ -27,7 +30,7 @@ apt_key_sig: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 keyring: "/etc/apt/trusted.gpg.d/docker.gpg"
 # Name of the apt repository for Docker CE or EE
 apt_repository_arch: "amd64"
-apt_repository: "deb [arch={{ apt_repository_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} stable"
+apt_repository: "deb [arch={{ apt_repository_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} {{ docker_apt_channel }}"
 
 # daemon_json allows you to configure the daemon with the daemon.json file.
 # https://docs.docker.com/engine/reference/commandline/dockerd/#on-linux

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,9 @@ uninstall_previous_docker_versions: false
 # assume that the desired version is community edition
 docker_edition: ce
 
-# which channel to pull from the apt repository
+# Which channel to pull from the apt repository; "edge" gets releases for new OS versions before
+# "stable" does, so if your OS isn't supported in "stable" you might still be able to install by
+# changing this to "edge". Other channels include "test" and "nightly".
 docker_apt_channel: stable
 
 # docker-ce is the default package name


### PR DESCRIPTION
This allows installation of nightly or edge releases without having to override the entire `apt_repository` variable.