### PR TITLE
Temporary hack to support bionic

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ apt_key_sig: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
 keyring: "/etc/apt/trusted.gpg.d/docker.gpg"
 # Name of the apt repository for Docker CE or EE
 apt_repository_arch: "amd64"
-apt_repository: "deb [arch={{ apt_repository_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} stable"
+apt_repository: "deb [arch={{ apt_repository_arch }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ (ansible_distribution_release|lower == 'bionic') | ternary('xenial', ansible_distribution_release|lower) }} stable"
 
 # daemon_json allows you to configure the daemon with the daemon.json file.
 # https://docs.docker.com/engine/reference/commandline/dockerd/#on-linux


### PR DESCRIPTION
Currently there aren't any official packages for bionic from docker, but
luckily the xenial packages work fine with bionic. So this temporary
hack is to facilitate installing the xenial package on bionic.