### PR TITLE
Prepare for Ansbile 2.5 deprecations

### DIFF
--- a/tasks/kernel_check_and_update.yml
+++ b/tasks/kernel_check_and_update.yml
@@ -8,7 +8,7 @@
     - linux-image-generic-lts-trusty
     - linux-headers-generic-lts-trusty
   register: kernel_result
-  when: "ansible_distribution_version|version_compare('12.04', '=')"
+  when: "ansible_distribution_version is version_compare('12.04', '=')"
 
 - name: Install Xorg packages for backported kernels (very optional)
   apt:
@@ -20,7 +20,7 @@
     - xserver-xorg-lts-trusty
     - libgl1-mesa-glx-lts-trusty
   register: xorg_pkg_result
-  when: "install_xorg_pkgs and (kernel_result|changed or kernel_result|success)"
+  when: "install_xorg_pkgs and (kernel_result is changed or kernel_result is succeeded)"
 
 - name: Install latest kernel for Ubuntu 13.04+
   apt:
@@ -31,8 +31,8 @@
   with_items:
     - "linux-image-extra-{{ ansible_kernel }}"
     - linux-image-extra-virtual
-  when: "ansible_distribution_version|version_compare('13.04', '=')
-      or ansible_distribution_version|version_compare('13.10', '=')
+  when: "ansible_distribution_version is version_compare('13.04', '=')
+      or ansible_distribution_version is version_compare('13.10', '=')
       or install_kernel_extras"
 
 # Fix for https://github.com/dotcloud/docker/issues/4568
@@ -43,14 +43,14 @@
     update_cache: yes
     cache_valid_time: 600
   register: cgroup_lite_result
-  when: "ansible_distribution_version|version_compare('13.10', '=')"
+  when: "ansible_distribution_version is version_compare('13.10', '=')"
 
 - name: Reboot instance
   command: /sbin/shutdown -r now
   register: reboot_result
-  when: "(ansible_distribution_version|version_compare('12.04', '=') and kernel_result|changed)
-      or (ansible_distribution_version|version_compare('13.10', '=') and cgroup_lite_result|changed)
-      or xorg_pkg_result|changed"
+  when: "(ansible_distribution_version is version_compare('12.04', '=') and kernel_result is changed)
+      or (ansible_distribution_version is version_compare('13.10', '=') and cgroup_lite_result is changed)
+      or xorg_pkg_result is changed"
 
 - name: Wait for instance to come online (10 minute timeout)
   become: no
@@ -61,5 +61,5 @@
     delay: 30
     timeout: 600
     state: started
-  when: "(ansible_distribution_version|version_compare('12.04', '=') and reboot_result|changed)
-      or (ansible_distribution_version|version_compare('13.10', '=') and cgroup_lite_result|changed)"
+  when: "(ansible_distribution_version is version_compare('12.04', '=') and reboot_result is changed)
+      or (ansible_distribution_version is version_compare('13.10', '=') and cgroup_lite_result is changed)"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,17 +6,17 @@
 - name: Fail if not a supported release of Ubuntu
   fail:
     msg: "{{ ansible_distribution_version }} is not an acceptable version of Ubuntu for this role"
-  when: ansible_lsb.id|lower == "ubuntu" and ansible_distribution_version|version_compare('14.04', '<')
+  when: ansible_lsb.id|lower == "ubuntu" and ansible_distribution_version is version_compare('14.04', '<')
 
 - name: Fail if not a new release of Debian
   fail:
     msg: "{{ ansible_distribution_version }} is not an acceptable version of Debian for this role"
-  when: ansible_lsb.id|lower == "debian" and ansible_distribution_version|version_compare('8.5', '<')
+  when: ansible_lsb.id|lower == "debian" and ansible_distribution_version is version_compare('8.5', '<')
 
 - name: Fail if using python3 with Ansible<2.3
   fail:
     msg: "Ansible 2.3+ is required to use Python3 interpreter."
-  when: ansible_version.full | version_compare('2.3', '<') and ansible_python_interpreter is defined and 'python3' in ansible_python_interpreter
+  when: ansible_version.full is version_compare('2.3', '<') and ansible_python_interpreter is defined and 'python3' in ansible_python_interpreter
 
 - name: Update kernel, kernel extras, Xorg pkgs, and related tasks
   include: kernel_check_and_update.yml
@@ -41,7 +41,7 @@
   with_items:
     - linux-image-extra-{{ ansible_kernel }}
     - linux-image-extra-virtual
-  when: docker_aufs_enabled and ansible_distribution_version|version_compare('14.04', '==')
+  when: docker_aufs_enabled and ansible_distribution_version is version_compare('14.04', '==')
   register: linux_image_extra_install
   ignore_errors: yes
 
@@ -51,7 +51,7 @@
     state: present
     update_cache: yes
     cache_valid_time: "{{ docker_apt_cache_valid_time }}"
-  when: linux_image_extra_install|failed
+  when: linux_image_extra_install is failed
 
 - name: Ensure dirmngr is available
   apt:
@@ -70,7 +70,7 @@
 
 - name: Alternative | Add Docker repository key
   shell: "apt-key adv --fetch-keys {{ apt_key_url }}"
-  when: add_repository_key|failed
+  when: add_repository_key is failed
 
 - name: HTTPS APT transport for Docker repository
   apt:
@@ -100,7 +100,7 @@
 - name: Set systemd playbook var
   set_fact:
     is_systemd: true
-  when: ( ansible_distribution == "Ubuntu" and ansible_distribution_version|version_compare('15.04', '>=') or ansible_distribution == "Debian" )
+  when: ( ansible_distribution == "Ubuntu" and ansible_distribution_version is version_compare('15.04', '>=') or ansible_distribution == "Debian" )
   tags: always
 
 - name: Set docker_http_proxy_defined flag
@@ -174,11 +174,11 @@
   when: docker_pkg_name == 'docker.io'
 
 - meta: flush_handlers
-  when: "dns_fix|changed"
+  when: "dns_fix is changed"
 
 - pause:
     seconds: 1
-  when: "dns_fix|changed"
+  when: "dns_fix is changed"
 
 # We must install pip via apt before we can use the pip module below
 - name: "Install {{ _python_packages | join(', ') }} packages with apt"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -20,15 +20,15 @@ python_vars_file: >-
 #   * you have to use docker-compose<=1.9.0 due to docker-compose>1.9.0 using newer versions of docker-py.
 
 # Compute Ansible version or latest
-_ansible_version_latest: "{{ ansible_version.full | version_compare('2.3', '<') }}"
+_ansible_version_latest: "{{ ansible_version.full is version_compare('2.3', '<') }}"
 
 # Compute Python Docker component version or latest
 _pip_version_docker_latest: >-
-  {{ pip_version_docker=='latest' or (pip_version_docker | version_compare('1.10.6', '>')) }}
+  {{ pip_version_docker=='latest' or (pip_version_docker is version_compare('1.10.6', '>')) }}
 
 # Compute Python Docker-compose component version or latest
 _pip_version_docker_compose_latest: >-
-  {{ pip_version_docker_compose=='latest' or (pip_version_docker_compose | version_compare('1.9.0', '>')) }}
+  {{ pip_version_docker_compose=='latest' or (pip_version_docker_compose is version_compare('1.9.0', '>')) }}
 
 # Compute the `docker` Python package's version to use.
 _pip_version_docker: >-


### PR DESCRIPTION
Change all Jinja filter tests to new format:
https://docs.ansible.com/ansible/2.5/porting_guides/porting_guide_2.5.html#deprecated

It should be backwards compatible.