### PR TITLE
Handle Ubuntu 14.04 w/ linux-aws kernel package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,8 @@
   with_items:
     - linux-image-extra-{{ ansible_kernel }}
     - linux-image-extra-virtual
-  when: docker_aufs_enabled and ansible_distribution_version is version_compare('14.04', '==')
+  when: docker_aufs_enabled and ansible_distribution_version is version_compare('14.04', '==') and ansible_kernel is version_compare('4.4', '<')
+
   register: linux_image_extra_install
   ignore_errors: yes
 


### PR DESCRIPTION
When using the linux-aws kernel package for EC2 instances, there are no
linux-image-extra packages. However, the kernel image package itself already
contains AuFS support, so the installation can just be skipped.