### PR TITLE
Install Linux image extra package for current kernel only (14.04)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.log
 env/
 venv/
+*.iml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,11 +31,10 @@
     state: absent
   when: uninstall_previous_docker_versions
 
-- name: Install linux-image-extra-* packages to enable AuFS driver
+- name: Install linux-image-extra package to enable AuFS driver
   apt:
     pkg:
       - linux-image-extra-{{ ansible_kernel }}
-      - linux-image-extra-virtual
     state: present
     update_cache: yes
     cache_valid_time: "{{ docker_apt_cache_valid_time }}"


### PR DESCRIPTION
Installing `linux-image-extra-virtual` without a version number will recursively pull in the newest kernel and update your system to that. This alone is probably unwanted/unexpected, but it can also break other things.

In our particular case it led to `sysdig` failing, because it needs the `linux-headers` package matching the running kernel in order to compile a kernel module via `dkms`. These headers, however, does not get installed via `linux-image-extra-virtual package`.

This patch removes the installation of the virtual package and instead only installs the extras matching the current kernel.