### PR TITLE
Prevent an ansible warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -181,7 +181,6 @@
   when: docker_pkg_name == 'docker.io'
 
 - meta: flush_handlers
-  when: "dns_fix is changed"
 
 - pause:
     seconds: 1


### PR DESCRIPTION
Currently for one of the steps ansible outputs a warning:

```
TASK [docker-ubuntu : Fix DNS in docker.io] ***************************************
skipping: [docker]
skipping: [gitea]
 [WARNING]: flush_handlers task does not support when conditional
```

I simply removed the when condition which prevents the warning and, assuming the message is correct, should not change the behaviour.