### PR TITLE
Explicitly install cli package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ docker_apt_channel: stable
 
 # docker-ce is the default package name
 docker_pkg_name: "{{ 'docker-ee' if docker_edition == 'ee' else 'docker-ce' }}"
+docker_cli_pkg_name: "{{ 'docker-ee-cli' if docker_edition == 'ee' else 'docker-ce-cli' }}"
 docker_apt_cache_valid_time: 600
 docker_aufs_enabled: true
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,6 +90,14 @@
     state: present
   environment: "{{ proxy_env if proxy_env is defined else {} }}"
 
+- name: Install (or update) docker-cli package
+  apt:
+    name: "{{ docker_cli_pkg_name }}"
+    state: "{{ 'latest' if update_docker_package else 'present' }}"
+    update_cache: "{{ update_docker_package }}"
+    cache_valid_time: "{{ docker_apt_cache_valid_time }}"
+  environment: "{{ proxy_env if proxy_env is defined else {} }}"
+
 - name: Install (or update) docker package
   apt:
     name: "{{ docker_pkg_name }}"


### PR DESCRIPTION
The docker-ce package depends on docker-ce-cli unconstrained, this
can lead to problems where the cli package is too new to communicate
with the daemon. This patch adds an explicit install task for the
cli package, so that it's version can be overridden if necessary.

Related conjurinc/ops#569