### PR TITLE
Upgrading the fork to latest version 3.9

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,10 @@
 ---
+ubuntu_version: {{ansible_lsb.id|lower }}-{{ ansible_lsb.codename|lower }}
 # docker-engine is the default package name
 docker_pkg_version: 17.05.0
 docker_pkg_edition: ce
-docker_pkg_name: docker-engine={{ docker_pkg_version }}~{{ docker_pkg_edition }}-0~{{ansible_lsb.id|lower }}-{{ ansible_lsb.codename|lower }}
+docker_pkg_apt_version: {{ docker_pkg_version }}~{{ docker_pkg_edition }}-0~{{ ubuntu_version }}
+docker_pkg_name: docker-engine={{ docker_pkg_apt_version }}
 docker_apt_cache_valid_time: 600
 
 # docker dns path for docker.io package ( changed at ubuntu 14.04 from docker to docker.io )
@@ -15,7 +17,7 @@ apt_key_url: hkp://p80.pool.sks-keyservers.net:80
 # apt repository key signature
 apt_key_sig: 58118E89F3A912897C070ADBF76221572C52609D
 # Name of the apt repository for docker
-apt_repository: deb https://apt.dockerproject.org/repo {{ ansible_lsb.id|lower }}-{{ ansible_lsb.codename|lower }} main
+apt_repository: deb https://apt.dockerproject.org/repo {{ ubuntu_version }} main
 # The following help expose a docker port or to add additional options when
 # running docker daemon.  The default is to not use any special options.
 #docker_opts: >

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,7 +56,8 @@ pip_version_docker_compose: latest
 kernel_update_and_reboot_permitted: no
 
 # Set to 'yes' or 'true' to enable updates (sets 'latest' in apt module)
-update_docker_package: yes
+update_docker_package: no
+update_docker_package_cache: yes
 
 # Change these to 'present' if you're running Ubuntu 12.04-13.10 and are fine with less-than-latest packages
 kernel_pkg_state: latest

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # docker-engine is the default package name
-docker_pkg_name: docker-engine
+docker_pkg_version: 17.05.0
+docker_pkg_edition: ce
+docker_pkg_name: docker-engine={{ docker_pkg_version }}~{{ docker_pkg_edition }}-0~{{ansible_lsb.id|lower }}-{{ ansible_lsb.codename|lower }}
 docker_apt_cache_valid_time: 600
 
 # docker dns path for docker.io package ( changed at ubuntu 14.04 from docker to docker.io )

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,15 +1,15 @@
 ---
-ubuntu_version: {{ansible_lsb.id|lower }}-{{ ansible_lsb.codename|lower }}
+ubuntu_version: "{{ansible_lsb.id|lower }}-{{ ansible_lsb.codename|lower }}"
 # docker-engine is the default package name
 docker_pkg_version: 17.05.0
 docker_pkg_edition: ce
-docker_pkg_apt_version: {{ docker_pkg_version }}~{{ docker_pkg_edition }}-0~{{ ubuntu_version }}
-docker_pkg_name: docker-engine{{ '' if docker_pkg_version=='latest' else '=' + docker_pkg_apt_version }}
+docker_pkg_apt_version: "{{ docker_pkg_version }}~{{ docker_pkg_edition }}-0~{{ ubuntu_version }}"
+docker_pkg_name: "docker-engine{{ '' if docker_pkg_version=='latest' else '=' + docker_pkg_apt_version }}"
 docker_apt_cache_valid_time: 600
     
 # For 12.04
-old_docker_pkg_apt_version: 17.04.0~{{ docker_pkg_edition }}-0~{{ ubuntu_version }}
-old_docker_pkg_name: docker-engine{{ '' if docker_pkg_version=='latest' else '=' + old_docker_pkg_apt_version }}
+old_docker_pkg_apt_version: "17.04.0~{{ docker_pkg_edition }}-0~{{ ubuntu_version }}"
+old_docker_pkg_name: "docker-engine{{ '' if docker_pkg_version=='latest' else '=' + old_docker_pkg_apt_version }}"
 
 # docker dns path for docker.io package ( changed at ubuntu 14.04 from docker to docker.io )
 docker_defaults_file_path: /etc/default/docker

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ ubuntu_version: {{ansible_lsb.id|lower }}-{{ ansible_lsb.codename|lower }}
 docker_pkg_version: 17.05.0
 docker_pkg_edition: ce
 docker_pkg_apt_version: {{ docker_pkg_version }}~{{ docker_pkg_edition }}-0~{{ ubuntu_version }}
-docker_pkg_name: docker-engine={{ docker_pkg_apt_version }}
+docker_pkg_name: docker-engine{{ '' if docker_pkg_version=='latest' else '=' + docker_pkg_apt_version }}
 docker_apt_cache_valid_time: 600
 
 # docker dns path for docker.io package ( changed at ubuntu 14.04 from docker to docker.io )
@@ -55,8 +55,7 @@ pip_version_docker_compose: latest
 # Warning: Use with caution in production environments.
 kernel_update_and_reboot_permitted: no
 
-# Set to 'yes' or 'true' to enable updates (sets 'latest' in apt module)
-update_docker_package: no
+# Set to 'yes' or 'true' to enable cache updates 
 update_docker_package_cache: yes
 
 # Change these to 'present' if you're running Ubuntu 12.04-13.10 and are fine with less-than-latest packages

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,7 +54,7 @@ pip_version_docker_compose: latest
 kernel_update_and_reboot_permitted: no
 
 # Set to 'yes' or 'true' to enable updates (sets 'latest' in apt module)
-update_docker_package: no
+update_docker_package: yes
 
 # Change these to 'present' if you're running Ubuntu 12.04-13.10 and are fine with less-than-latest packages
 kernel_pkg_state: latest

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,14 +45,14 @@ docker_https_proxy:
 # Flags for whether to install pip packages
 pip_install_pip: true
 pip_install_setuptools: true
-pip_install_docker_py: true
+pip_install_docker: true
 pip_install_docker_compose: true
 install_docker_py_on_1604: false
 
 # Versions for the python packages that are installed
 pip_version_pip: latest
 pip_version_setuptools: latest
-pip_version_docker_py: latest
+pip_version_docker: latest
 pip_version_docker_compose: latest
 
 # If this variable is set to true kernel updates and host restarts are permitted.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,10 @@ docker_pkg_edition: ce
 docker_pkg_apt_version: {{ docker_pkg_version }}~{{ docker_pkg_edition }}-0~{{ ubuntu_version }}
 docker_pkg_name: docker-engine{{ '' if docker_pkg_version=='latest' else '=' + docker_pkg_apt_version }}
 docker_apt_cache_valid_time: 600
+    
+# For 12.04
+old_docker_pkg_apt_version: 17.04.0~{{ docker_pkg_edition }}-0~{{ ubuntu_version }}
+old_docker_pkg_name: docker-engine{{ '' if docker_pkg_version=='latest' else '=' + old_docker_pkg_apt_version }}
 
 # docker dns path for docker.io package ( changed at ubuntu 14.04 from docker to docker.io )
 docker_defaults_file_path: /etc/default/docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -155,15 +155,13 @@
   when: "dns_fix|changed"
 
 # We must install pip via apt before we can use the pip module below
-- name: Install pip, python-dev package with apt
+- name: "Install {{ _python_packages | join(', ') }} packages with apt"
   apt:
     pkg: "{{ item }}"
     state: latest
     update_cache: yes
     cache_valid_time: "{{ docker_apt_cache_valid_time }}"
-  with_items:
-    - python-dev
-    - python-pip
+  with_items: "{{ _python_packages }}"
 
 # Display an informative message if the docker-compose version needs to be downgraded
 - name: Docker-compose version downgrade

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,12 +69,21 @@
     update_cache: yes
     state: present
 
-- name: Install (or update) docker package
+- name: Install (or update) docker package 12.04
+  apt:
+    name: "{{ old_docker_pkg_name }}"
+    state: "{{ 'latest' if old_docker_pkg_version=='latest' else 'present' }}"
+    update_cache: "{{ update_docker_package_cache }}"
+    cache_valid_time: "{{ docker_apt_cache_valid_time }}"
+  when: ansible_distribution_version|version_compare('12.04', '=')
+
+- name: Install (or update) docker package 14.04+
   apt:
     name: "{{ docker_pkg_name }}"
     state: "{{ 'latest' if docker_pkg_version=='latest' else 'present' }}"
     update_cache: "{{ update_docker_package_cache }}"
     cache_valid_time: "{{ docker_apt_cache_valid_time }}"
+  when: ansible_distribution_version|version_compare('12.04', '!=')
 
 - name: Set systemd playbook var
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -174,6 +174,20 @@
       module in Ansible < 2.3
   when: pip_install_docker_compose and _pip_version_docker_compose != pip_version_docker_compose
 
+# See vars/main.yml for more information on this.
+- name: Clean previous docker-py package if installing docker.
+  pip:
+    name: docker-py
+    state: absent
+  when: (_pip_install_docker or pip_install_docker_compose) and _pip_docker_package_name == 'docker'
+
+# See vars/main.yml for more information on this.
+- name: Clean previous docker package if installing docker-py.
+  pip:
+    name: docker
+    state: absent
+  when: (_pip_install_docker or pip_install_docker_compose) and _pip_docker_package_name == 'docker-py'
+
 # Upgrade pip with pip to fix angstwad/docker.ubuntu/pull/35 and docker-py/issues/525
 - name: Install pip, setuptools, docker-py and docker-compose with pip
   pip:
@@ -187,9 +201,9 @@
     - name: setuptools
       version: "{{ pip_version_setuptools }}"
       install: "{{ pip_install_setuptools }}"
-    - name: docker-py
-      version: "{{ pip_version_docker_py }}"
-      install: "{{ pip_install_docker_py and (install_docker_py_on_1604 or not ansible_distribution_version|version_compare('16.04', '>=')) }}"
+    - name: "{{ _pip_docker_package_name }}"
+      version: "{{ pip_version_docker }}"
+      install: "{{ _pip_install_docker }}"
     - name: docker-compose
       version: "{{ _pip_version_docker_compose }}"
       install: "{{ pip_install_docker_compose }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,7 +73,7 @@
   apt:
     name: "{{ docker_pkg_name }}"
     state: "{{ 'latest' if update_docker_package else 'present' }}"
-    update_cache: "{{ update_docker_package }}"
+    update_cache: "{{ update_docker_package_cache }}"
     cache_valid_time: "{{ docker_apt_cache_valid_time }}"
 
 - name: Set systemd playbook var

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,7 +72,7 @@
 - name: Install (or update) docker package
   apt:
     name: "{{ docker_pkg_name }}"
-    state: "{{ 'latest' if update_docker_package else 'present' }}"
+    state: "{{ 'latest' if docker_pkg_version=='latest' else 'present' }}"
     update_cache: "{{ update_docker_package_cache }}"
     cache_valid_time: "{{ docker_apt_cache_valid_time }}"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,9 @@
 ---
+# Select python variable file according to the ansible_python_interpreter.
+python_vars_file: >-
+  {{ 'python3.yml' if ansible_python_interpreter is defined
+                          and 'python3' in ansible_python_interpreter
+                       else 'python2.yml' }}
 # To use Docker Ansible modules, managed nodes require some Docker Python packages :
 # * `docker-py` (renamed into `docker` since the 2.0.0 version);
 # * `docker-compose` which is required by the docker_service Ansible module.
@@ -13,20 +18,26 @@
 #   * you have to use docker-py<=1.10.6 due to backward incompatibilities of next versions
 #   * you have to use docker-compose<=1.9.0 due to docker-compose>1.9.0 using newer versions of docker-py.
 
+# Compute Ansible version or latest
+_ansible_version_latest: "{{ ansible_version.full | version_compare('2.3', '<') }}"
+
+# Compute Python Docker component version or latest
+_pip_version_docker_latest: >-
+  {{ pip_version_docker=='latest' or (pip_version_docker | version_compare('1.10.6', '>')) }}
+# Compute Python Docker-compose component version or latest
+_pip_version_docker_compose_latest: >-
+  {{ pip_version_docker_compose=='latest' or (pip_version_docker_compose | version_compare('1.9.0', '>')) }}
 # Compute the `docker` Python package's version to use.
 _pip_version_docker: >-
-    {{ '1.10.6' if ansible_version.full | version_compare('2.3', '<')
-        and (pip_version_docker=='latest' or pip_version_docker | version_compare('1.10.6', '>'))
-        else pip_version_docker }}
+  {{ '1.10.6' if (_ansible_version_latest and _pip_version_docker_latest) else pip_version_docker }}
 # Compute the `docker` Python package's name according to its version.
-_pip_docker_package_name: "{{ 'docker-py' if pip_version_docker | version_compare('1.10.6', '<=') else 'docker' }}"
+_pip_docker_package_name: "{{ 'docker-py' if not _pip_version_docker_latest else 'docker' }}"
 
-# Determine whether to install the `docker` package or not. The `docker-compose` Python package has a dependency over the `docker` Python package.
-# So when installing the `docker-compose` package we'd rather let it handle the `docker` package version to prevent version mismatches.
+# Determine whether to install the `docker` package or not. The `docker-compose` Python package has a dependency over
+# the `docker` Python package. So when installing the `docker-compose` package we'd rather let it handle the `docker`
+# package version to prevent version mismatches.
 _pip_install_docker: "{{ not pip_install_docker_compose and pip_install_docker }}"
 
 # Compute the `docker-compose` Python package's version to use.
 _pip_version_docker_compose: >-
-    {{ '1.9.0' if ansible_version.full | version_compare('2.3', '<')
-        and (pip_version_docker_compose=='latest' or pip_version_docker_compose | version_compare('1.9.0', '>'))
-        else pip_version_docker_compose }}
+  {{ '1.9.0' if (_ansible_version_latest and _pip_version_docker_compose_latest) else pip_version_docker_compose }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,31 @@
 ---
-# Downgrade docker-compose version if ansible version < 2.3 and docker-compose > 1.9.0
-# Because of docker-compose 1.10+ requires docker python package (instead of the docker-py one)
-# which is incompatible with the docker_container module in Ansible < 2.3
-# TODO: update ansible version in the comparison when https://github.com/ansible/ansible/issues/20492 gets fixed.
+# To use Docker Ansible modules, managed nodes require some Docker Python packages :
+# * `docker-py` (renamed into `docker` since the 2.0.0 version);
+# * `docker-compose` which is required by the docker_service Ansible module.
+#
+# The `docker` python package introduces some backward incompatible changes is version 2.0.0.
+# Ansible 2.3+ is required to run this new version. Previous Ansible versions have to use docker-py<=1.10.6.
+# The `docker-compose` python package has a dependency over the docker/docker-py package.
+# The `docker-compose` 1.9.0 is the latest version to be compatible with the docker<2.0.0.
+#
+# To sum up:
+# * with Ansible < 2.3:
+#   * you have to use docker-py<=1.10.6 due to backward incompatibilities of next versions
+#   * you have to use docker-compose<=1.9.0 due to docker-compose>1.9.0 using newer versions of docker-py.
+
+# Compute the `docker` Python package's version to use.
+_pip_version_docker: >-
+    {{ '1.10.6' if ansible_version.full | version_compare('2.3', '<')
+        and (pip_version_docker=='latest' or pip_version_docker | version_compare('1.10.6', '>'))
+        else pip_version_docker }}
+# Compute the `docker` Python package's name according to its version.
+_pip_docker_package_name: "{{ 'docker-py' if pip_version_docker | version_compare('1.10.6', '<=') else 'docker' }}"
+
+# Determine whether to install the `docker` package or not. The `docker-compose` Python package has a dependency over the `docker` Python package.
+# So when installing the `docker-compose` package we'd rather let it handle the `docker` package version to prevent version mismatches.
+_pip_install_docker: "{{ not pip_install_docker_compose and pip_install_docker }}"
+
+# Compute the `docker-compose` Python package's version to use.
 _pip_version_docker_compose: >-
     {{ '1.9.0' if ansible_version.full | version_compare('2.3', '<')
         and (pip_version_docker_compose=='latest' or pip_version_docker_compose | version_compare('1.9.0', '>'))

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,9 +1,13 @@
 ---
 # Select python variable file according to the ansible_python_interpreter.
-python_vars_file: >-
-  {{ 'python3.yml' if ansible_python_interpreter is defined
-                          and 'python3' in ansible_python_interpreter
-                       else 'python2.yml' }}
+_python_packages:
+  - python-dev
+  - python-pip
+_pip_executable: pip
+#python_vars_file: >-
+#  {{ 'python3.yml' if ansible_python_interpreter is defined
+#                          and 'python3' in ansible_python_interpreter
+#                       else 'python2.yml' }}
 # To use Docker Ansible modules, managed nodes require some Docker Python packages :
 # * `docker-py` (renamed into `docker` since the 2.0.0 version);
 # * `docker-compose` which is required by the docker_service Ansible module.

--- a/vars/python2.yml
+++ b/vars/python2.yml
@@ -1,0 +1,8 @@
+
+# Python2 specific variables.
+
+_python_packages:
+  - python-dev
+  - python-pip
+
+_pip_executable: pip

--- a/vars/python3.yml
+++ b/vars/python3.yml
@@ -1,0 +1,7 @@
+# Python3 specific variables.
+
+_python_packages:
+  - python3-dev
+  - python3-pip
+
+_pip_executable: pip3


### PR DESCRIPTION
We would like to update the way, how this Galaxy role detects Python version for interpreter. To do that, we need to first update this fork to latest 3.9 and then we can do necessary upgrades.